### PR TITLE
feat(#28): Let Claude Cook mode — autonomous work with non-interrupting communication

### DIFF
--- a/commands/cook.md
+++ b/commands/cook.md
@@ -1,0 +1,72 @@
+---
+name: cook
+description: Activate "Let Claude Cook" mode — autonomous work with queued user messages
+---
+
+# /cook — Let Claude Cook 🔥
+
+Activate autonomous work mode. While cooking:
+- Claude works continuously without interruption
+- User messages are queued (via btw system) instead of interrupting workflow
+- Claude acknowledges queued messages briefly and continues working
+- Between major task boundaries, Claude checks and processes the queue
+
+## Activation
+
+When this command is invoked:
+
+$ARGUMENTS
+
+1. Source the cook library and activate:
+   ```bash
+   source ~/.claude/lib/cook.sh
+   cook_activate "$ARGUMENTS"
+   ```
+
+2. Respond with a fun cooking-themed confirmation, e.g.:
+   - "🔥 Kitchen's hot — let me cook!"
+   - "🍳 Chef's in the zone. Messages will be queued."
+   - "👨‍🍳 Apron on. I'll check your messages between courses."
+
+3. **CRITICAL BEHAVIORAL CHANGE — From this point forward:**
+
+   When cook mode is active (`~/.claude/state/cook-mode.json` has `"active": true`):
+
+   a. **On receiving any user message:**
+      - First, check if it contains an exit keyword: `cook_check_exit "<message>"`
+      - If exit keyword detected → run `/uncook` behavior (deactivate, show summary)
+      - Otherwise → queue it: `cook_queue_message "<message>"`
+      - Respond ONLY with a brief single-line acknowledgment like:
+        `📝 Queued: "<brief summary of message>"`
+      - Immediately continue your current task. Do NOT engage with message content.
+
+   b. **Between major task completions:**
+      - Check the btw queue: `source ~/.claude/lib/btw.sh && btw_check`
+      - If items pending, review them and decide:
+        - Urgent/relevant to current work → process inline
+        - Everything else → leave queued for later
+      - Continue to next task
+
+   c. **Exit keywords** that deactivate cook mode:
+      - "stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"
+      - Or the `/uncook` command
+
+   d. **The mode persists across context compactions** because state is stored in the filesystem at `~/.claude/state/cook-mode.json`
+
+## Example Session
+
+```
+User: /cook implementing the auth system
+Claude: 🔥 Kitchen's hot! Working on: implementing the auth system
+        Messages will be queued — say "stop" or /uncook to exit cook mode.
+
+User: oh also make sure to add rate limiting
+Claude: 📝 Queued: "add rate limiting"
+[continues working on auth system]
+
+User: hey
+Claude: 🍳 Cook mode deactivated!
+        1 message was queued:
+        1. "oh also make sure to add rate limiting"
+        Ready for normal conversation.
+```

--- a/commands/uncook.md
+++ b/commands/uncook.md
@@ -1,0 +1,32 @@
+---
+name: uncook
+description: Exit "Let Claude Cook" mode and show queued message summary
+---
+
+# /uncook — Exit Cook Mode
+
+Deactivate cook mode and return to normal interactive behavior.
+
+## Behavior
+
+When this command is invoked:
+
+1. Source the cook library and deactivate:
+   ```bash
+   source ~/.claude/lib/cook.sh
+   cook_deactivate
+   ```
+
+2. Display the summary output from `cook_deactivate`, which shows:
+   - How long the cook session lasted
+   - How many messages were queued
+   - List of all queued messages with timestamps
+
+3. Return to normal interactive behavior — respond to user messages directly instead of queuing them.
+
+4. If there are queued messages, offer to process them:
+   - "Would you like me to go through the queued messages now?"
+   - Or process them directly if the context makes it clear
+
+5. If cook mode was not active, say so:
+   - "Cook mode isn't active. Use `/cook` to start an autonomous work session."

--- a/docs/cook-mode.md
+++ b/docs/cook-mode.md
@@ -1,0 +1,75 @@
+# Cook Mode — "Let Claude Cook" 🔥
+
+## Overview
+
+Cook mode enables autonomous work sessions where Claude works continuously without interruption. User messages are queued via the btw system and processed at task boundaries.
+
+## Commands
+
+- **`/cook [task description]`** — Activate cook mode with an optional task description
+- **`/uncook`** — Deactivate cook mode and show queued message summary
+- **Exit keywords**: "stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"
+
+## Architecture
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `~/.claude/lib/cook.sh` | Shell helpers (activate, deactivate, queue, check exit) |
+| `~/.claude/commands/cook.md` | `/cook` slash command definition |
+| `~/.claude/commands/uncook.md` | `/uncook` slash command definition |
+| `~/.claude/state/cook-mode.json` | Persistent state file |
+
+### State File Schema
+
+```json
+{
+  "active": true,
+  "started_at": "2026-03-11T10:30:00",
+  "task": "Implementing auth system",
+  "messages_queued": 3,
+  "exit_keywords": ["stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"]
+}
+```
+
+### Integration Points
+
+- **Statusline**: Shows `🔥 COOKING` prefix when active
+- **HQ Dashboard**: Displays cook mode badge with task and queue count
+- **btw queue**: Queued messages are tagged with `cook_mode: true`
+- **hq-status-writer.py**: Exposes `cook_mode` field in status.json
+
+## Behavioral Contract
+
+When cook mode is active:
+
+1. **User messages are queued**, not processed inline
+2. **Brief acknowledgment** is given: `📝 Queued: "<summary>"`
+3. **Exit keywords** checked before queuing — if detected, cook mode deactivates
+4. **Task boundaries** are natural checkpoints to review the queue
+5. **State persists** across context compactions (stored on filesystem)
+
+## Shell Library API
+
+```bash
+source ~/.claude/lib/cook.sh
+
+cook_is_active              # Returns 0 if active, 1 if not
+cook_activate "my task"     # Activates cook mode
+cook_deactivate             # Deactivates and shows summary
+cook_queue_message "text"   # Queues a message with cook_mode tag
+cook_check_exit "stop"      # Prints "exit" or "continue"
+```
+
+## Installation
+
+The cook.sh library and command files are installed from wasteland-orchestrator:
+
+```bash
+# From the repo:
+cp lib/cook.sh ~/.claude/lib/cook.sh
+cp commands/cook.md ~/.claude/commands/cook.md
+cp commands/uncook.md ~/.claude/commands/uncook.md
+mkdir -p ~/.claude/state
+```

--- a/lib/cook.sh
+++ b/lib/cook.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# cook.sh — Shell helpers for "Let Claude Cook" mode
+#
+# Source in agent sessions:
+#   source ~/.claude/lib/cook.sh
+#
+# Functions:
+#   cook_is_active       — returns 0 if cook mode active, 1 if not
+#   cook_activate        — writes state file, prints confirmation
+#   cook_deactivate      — clears state, prints summary
+#   cook_queue_message   — wraps btw queue with cook-mode tagging
+#   cook_check_exit      — checks if a message contains exit keywords
+
+COOK_STATE_FILE="${HOME}/.claude/state/cook-mode.json"
+
+# Ensure state dir exists
+mkdir -p "$(dirname "$COOK_STATE_FILE")" 2>/dev/null
+
+cook_is_active() {
+  if [[ ! -f "$COOK_STATE_FILE" ]]; then
+    return 1
+  fi
+  local active
+  active=$(python3 -c "
+import json, os
+try:
+    with open(os.path.expanduser('$COOK_STATE_FILE')) as f:
+        data = json.load(f)
+    print('yes' if data.get('active', False) else 'no')
+except:
+    print('no')
+" 2>/dev/null)
+  [[ "$active" == "yes" ]]
+}
+
+cook_activate() {
+  local task="${1:-Autonomous work session}"
+  python3 << PYEOF
+import json, os, datetime
+
+state = {
+    "active": True,
+    "started_at": datetime.datetime.now().isoformat(),
+    "task": """${task}""",
+    "messages_queued": 0,
+    "exit_keywords": ["stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"]
+}
+
+os.makedirs(os.path.dirname("$COOK_STATE_FILE"), exist_ok=True)
+with open("$COOK_STATE_FILE", "w") as f:
+    json.dump(state, f, indent=2)
+
+print("🔥 LET HIM COOK — Cook mode activated!")
+print(f"   Task: {state['task']}")
+print(f"   Started: {state['started_at'][:19]}")
+print("   User messages will be queued as btw items.")
+print("   Say 'stop', 'pause', or 'hey' to exit cook mode.")
+PYEOF
+}
+
+cook_deactivate() {
+  if [[ ! -f "$COOK_STATE_FILE" ]]; then
+    echo "Cook mode is not active."
+    return 1
+  fi
+
+  python3 << 'PYEOF'
+import json, os, datetime
+
+state_file = os.path.expanduser("~/.claude/state/cook-mode.json")
+btw_file = os.path.expanduser("~/.claude/btw-queue.json")
+
+try:
+    with open(state_file) as f:
+        state = json.load(f)
+except:
+    print("Cook mode is not active.")
+    exit(1)
+
+if not state.get("active"):
+    print("Cook mode is not active.")
+    exit(1)
+
+started = state.get("started_at", "unknown")
+queued = state.get("messages_queued", 0)
+task = state.get("task", "unknown")
+
+# Read queued btw items tagged with cook-mode
+cook_items = []
+try:
+    with open(btw_file) as f:
+        btw = json.load(f)
+    cook_items = [i for i in btw["items"]
+                  if not i.get("processed") and i.get("cook_mode")]
+except:
+    pass
+
+# Deactivate
+state["active"] = False
+state["ended_at"] = datetime.datetime.now().isoformat()
+with open(state_file, "w") as f:
+    json.dump(state, f, indent=2)
+
+print("🍳 Cook mode deactivated!")
+print(f"   Task: {task}")
+print(f"   Session started: {started[:19]}")
+print(f"   Messages queued: {queued}")
+
+if cook_items:
+    print("\n   Queued messages:")
+    for i, item in enumerate(cook_items, 1):
+        ts = item.get("timestamp", "?")[:16]
+        print(f"   {i}. [{ts}] {item['text']}")
+    print(f"\n   Process these with: btw  (or btw_read)")
+else:
+    print("   No messages were queued during this session.")
+PYEOF
+}
+
+cook_queue_message() {
+  local message="$*"
+  if [[ -z "$message" ]]; then
+    echo "No message to queue."
+    return 1
+  fi
+
+  python3 << PYEOF
+import json, os, datetime
+
+btw_file = os.path.expanduser("~/.claude/btw-queue.json")
+state_file = os.path.expanduser("~/.claude/state/cook-mode.json")
+
+# Ensure btw file exists
+if not os.path.exists(btw_file):
+    with open(btw_file, "w") as f:
+        json.dump({"items": [], "processed": []}, f)
+
+with open(btw_file) as f:
+    btw = json.load(f)
+
+btw["items"].append({
+    "text": """${message}""",
+    "timestamp": datetime.datetime.now().isoformat(),
+    "processed": False,
+    "cook_mode": True,
+})
+
+with open(btw_file, "w") as f:
+    json.dump(btw, f, indent=2)
+
+# Update cook state counter
+try:
+    with open(state_file) as f:
+        state = json.load(f)
+    state["messages_queued"] = state.get("messages_queued", 0) + 1
+    with open(state_file, "w") as f:
+        json.dump(state, f, indent=2)
+except:
+    pass
+
+count = len([i for i in btw["items"] if not i.get("processed")])
+print(f"📝 Queued ({count} pending)")
+PYEOF
+}
+
+cook_check_exit() {
+  local message="$*"
+  local message_lower
+  message_lower=$(echo "$message" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+  # Check against exit keywords
+  python3 << PYEOF
+import json, os
+
+state_file = os.path.expanduser("~/.claude/state/cook-mode.json")
+msg = """${message_lower}""".strip().lower()
+
+try:
+    with open(state_file) as f:
+        state = json.load(f)
+    keywords = state.get("exit_keywords", ["stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"])
+except:
+    keywords = ["stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"]
+
+# Exact match or starts-with for multi-word keywords
+for kw in keywords:
+    if msg == kw or msg.startswith(kw + " ") or msg.startswith(kw + ",") or msg.startswith(kw + "."):
+        print("exit")
+        exit(0)
+
+# Also check /uncook command
+if msg.strip().startswith("/uncook"):
+    print("exit")
+    exit(0)
+
+print("continue")
+PYEOF
+}


### PR DESCRIPTION
## Summary

- Add `/cook` and `/uncook` slash commands for autonomous work sessions
- Create `cook.sh` shell library with activate/deactivate/queue/exit-check helpers
- State persisted in `~/.claude/state/cook-mode.json` (survives context compactions)
- User messages queued via btw system during cook sessions, acknowledged briefly
- Exit keywords (stop, pause, hey, etc.) to break out of cook mode
- Full documentation in `docs/cook-mode.md`

Closes tquick/wasteland-orchestrator#28 (Gitea)

## Test Plan

- [x] All cook.sh functions tested and working
- [x] Statusline shows cook indicator when active
- [ ] End-to-end: activate, queue messages, deactivate

🤖 Generated with [Claude Code](https://claude.com/claude-code)