### PR TITLE
refactor(#52): replace agile terminology across codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ See `skills/agent-protocol/SKILL.md` for the full protocol specification.
 from lib.agent_tx import Transaction
 
 tx = Transaction("dev-lead-ms")
-tx.begin("Implementing assistant skeleton", "Sprint 1 story #17", repo="tquick/meeting-scribe", issue=17)
+tx.begin("Implementing assistant skeleton", "Phase 1 task #17", repo="tquick/meeting-scribe", issue=17)
 tx.action("Created src/assistant.py", "Core assistant class with Ollama client")
 tx.action("Updated pipeline.py", "Integrated assistant as post-transcription stage")
 tx.end("success", "Assistant skeleton in place, ready for model integration")

--- a/commands/status.md
+++ b/commands/status.md
@@ -19,13 +19,13 @@ When the user runs `/status`, do the following:
 ## Agent Status
 | Agent | State | Task | Last Heartbeat | Alive |
 |-------|-------|------|----------------|-------|
-| pm | working | Planning sprint 2 | 30s ago | yes |
+| pm | working | Planning phase 2 | 30s ago | yes |
 | dev-lead-ms | idle | Ready | 2m ago | yes |
 
 ## Active Transactions
 | Agent | Intent | Actions | Started |
 |-------|--------|---------|---------|
-| pm | Planning sprint 2 | 3 actions | 5m ago |
+| pm | Planning phase 2 | 3 actions | 5m ago |
 ```
 
 4. Flag any stale agents (heartbeat > 5 minutes) or dead processes

--- a/commands/tx.md
+++ b/commands/tx.md
@@ -13,7 +13,7 @@ Manage work transactions for audit trail and dashboard visibility.
 Start a new transaction:
 ```bash
 source ~/.claude/lib/agent-tx.sh
-tx_begin "Implementing feature X" "Sprint 1 story #42" "tquick/repo" 42
+tx_begin "Implementing feature X" "Phase 1 task #42" "tquick/repo" 42
 ```
 
 ### `/tx action <what> | <why>`

--- a/docs/plans/2026-03-09-orchestrator-v1.md
+++ b/docs/plans/2026-03-09-orchestrator-v1.md
@@ -1,0 +1,140 @@
+# Wasteland Orchestrator v1.0 — Phase Plan
+
+> **Priority**: This is THE priority. Orchestrator v1 unblocks everything else.
+> **Approved**: 2026-03-09
+> **Issues**: #1, #2, #3, #4, #5, #6
+
+---
+
+## What We Have (v0.1.0)
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Agent status files | **Working** | JSON at ~/.claude/agents/status/*.json |
+| Status Python lib | **Working** | `AgentStatus` class, `list_agents()` |
+| Transaction system | **Working** | `Transaction` class, begin/action/end, log archive |
+| Gitea API client | **Working** | `GiteaClient` with dual-auth, CRUD for issues |
+| PreToolUse hook | **Working** | Heartbeat, Gitea enforcement, worktree warnings |
+| Stop hook | **Working** | Status cleanup, interrupted tx archival |
+| Bash shell libs | **Working** | agent-status.sh, gitea-api.sh, agent-tx.sh |
+| Slash commands | **Working** | /status, /tx |
+
+## What We Need (v1.0)
+
+| Component | Issue | Complexity |
+|-----------|-------|-----------|
+| Phase manifest format | #1 | small |
+| Dispatcher (the brain) | #2 | large |
+| Health monitor | #3 | medium |
+| Conflict detection | #4 | medium |
+| Gitea auto-updates | #5 | small |
+| PM manifest generator | #6 | small |
+
+---
+
+## Implementation Order
+
+### Phase 1: Foundation (do first, enables everything)
+
+**#1 Phase Manifest** → Define the YAML format. Everything reads from this.
+
+**#6 PM Manifest Generator** → So we can auto-produce manifests from Gitea issues.
+
+### Phase 2: Core Dispatcher (the main build)
+
+**#2 Dispatcher** → The main `swarm.py` that:
+- Parses manifest
+- Builds dependency DAG
+- Spawns `claude -p` agents with correct context
+- Tracks PIDs and maps to tasks
+- Waits for completion
+
+### Phase 3: Safety & Polish
+
+**#4 Conflict Detection** → File ownership graph, serialization of overlapping tasks.
+
+**#3 Health Monitor** → Heartbeat checks, stall detection, retry logic.
+
+**#5 Gitea Integration** → Auto-close issues, progress comments.
+
+---
+
+## Architecture
+
+```
+                    ┌─────────────────────┐
+                    │   PM Agent (Elara)  │
+                    │  Designs phase,    │
+                    │  generates manifest │
+                    └─────────┬───────────┘
+                              │
+                              ▼
+                    ┌─────────────────────┐
+                    │    phase.yaml      │
+                    │  (manifest file)    │
+                    └─────────┬───────────┘
+                              │
+                              ▼
+            ┌─────────────────────────────────┐
+            │        swarm.py (dispatcher)     │
+            │                                  │
+            │  ┌──────────┐  ┌──────────────┐ │
+            │  │ DAG /    │  │  Conflict    │ │
+            │  │ Scheduler│  │  Detector    │ │
+            │  └────┬─────┘  └──────────────┘ │
+            │       │                          │
+            │  ┌────┴─────────────────────┐   │
+            │  │     Agent Monitor        │   │
+            │  │  heartbeat / stall /     │   │
+            │  │  retry / Gitea updates   │   │
+            │  └──┬──────┬──────┬─────────┘   │
+            └─────┼──────┼──────┼─────────────┘
+                  │      │      │
+          ┌───────┘      │      └───────┐
+          ▼              ▼              ▼
+    ┌──────────┐  ┌──────────┐  ┌──────────┐
+    │ claude -p│  │ claude -p│  │ claude -p│
+    │ dev-ui   │  │ dev-intg │  │ dev-test │
+    │ task #8 │  │ task #16│  │ task #17│
+    └──────────┘  └──────────┘  └──────────┘
+          │              │              │
+          ▼              ▼              ▼
+    status/*.json  status/*.json  status/*.json
+```
+
+## Key Design Decisions
+
+1. **`claude -p` not interactive sessions**: Print mode exits when done, gives us clean process lifecycle. Budget caps work. Output is capturable.
+
+2. **YAML manifest not database**: Human-editable, version-controllable, reviewable before dispatch. PM can tweak before launching.
+
+3. **File-based monitoring not IPC**: Status JSON files are the communication channel. No sockets, no message queues. Simple, debuggable, already working.
+
+4. **Serialization over conflict resolution**: v1 prevents conflicts by never running overlapping tasks in parallel. Smarter merging can come in v2.
+
+5. **One worktree per phase, not per task**: Keeps git simple. Tasks run sequentially when they share files, so the single worktree stays clean.
+
+---
+
+## Success Criteria
+
+After v1.0, running a phase looks like:
+
+```bash
+# PM generates manifest from Gitea issues
+python3 generate_manifest.py tquick/claude-gate --output phase.yaml
+
+# Human reviews/tweaks manifest
+vim phase.yaml
+
+# Launch the swarm
+python3 swarm.py phase.yaml
+
+# Watch progress (separate terminal)
+python3 swarm.py --status
+
+# Or just watch Gitea — issues auto-close as tasks complete
+```
+
+No manual `claude -p` commands. No copy-pasting prompts. No checking terminals.
+The dispatcher handles spawn, monitor, retry, report, close.

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -227,7 +227,7 @@ Thomas / contributors
 | **Pixel** | Mobile UX | Mobile UI/UX design, accessibility, interaction patterns |
 | **Sigil** | Brand Designer | Visual identity, style guides, marketing assets |
 | **Dev Team Lead** | Phase Coordinator | Per-project implementation, agent dispatch, review cycle |
-| **Documentation Agent** | Docs Keeper | Changelog, README, CLAUDE.md reconciliation, end-of-sprint docs |
+| **Documentation Agent** | Docs Keeper | Changelog, README, CLAUDE.md reconciliation, end-of-phase docs |
 
 ---
 

--- a/generate_manifest.py
+++ b/generate_manifest.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Generate a sprint manifest YAML from Gitea in-sprint issues.
+"""Generate a phase manifest YAML from Gitea issues.
 
 Queries Gitea for open issues with the 'in-sprint' label (or a specified
-milestone) and produces a sprint.yaml suitable for the dispatcher.
+milestone) and produces a phase.yaml suitable for the dispatcher.
 
 Usage:
-    python3 generate_manifest.py tquick/claude-gate --output sprint.yaml
+    python3 generate_manifest.py tquick/claude-gate --output phase.yaml
     python3 generate_manifest.py tquick/claude-gate --milestone 3
     python3 generate_manifest.py tquick/claude-gate --label in-sprint
 """
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 from lib.gitea_api import GiteaClient
-from lib.manifest import SprintManifest, Story
+from lib.manifest import PhaseManifest, Task
 
 
 def extract_files(body: str) -> list[str]:
@@ -42,7 +42,7 @@ def extract_files(body: str) -> list[str]:
 
 
 def extract_depends_on(body: str) -> list[str]:
-    """Extract dependency story IDs from issue body.
+    """Extract dependency task IDs from issue body.
 
     Looks for 'depends on: #X, #Y' or a '## Dependencies' section.
     """
@@ -73,18 +73,18 @@ def extract_agent(issue: dict) -> str:
 def issues_to_manifest(
     repo: str,
     issues: list[dict],
-    sprint_name: str = "",
+    phase_name: str = "",
     max_parallel: int = 3,
-) -> SprintManifest:
-    """Convert Gitea issues to a SprintManifest."""
-    stories = []
+) -> PhaseManifest:
+    """Convert Gitea issues to a PhaseManifest."""
+    tasks = []
     for issue in issues:
-        story_id = f"#{issue['number']}"
+        task_id = f"#{issue['number']}"
         body = issue.get("body", "") or ""
 
-        stories.append(
-            Story(
-                id=story_id,
+        tasks.append(
+            Task(
+                id=task_id,
                 title=issue["title"],
                 agent=extract_agent(issue),
                 repo=repo,
@@ -98,26 +98,26 @@ def issues_to_manifest(
         )
 
     # Sort by issue number for deterministic ordering
-    stories.sort(key=lambda s: s.issue or 0)
+    tasks.sort(key=lambda s: s.issue or 0)
 
-    return SprintManifest(
-        sprint=sprint_name or f"{repo.split('/')[-1]}-sprint",
+    return PhaseManifest(
+        phase=phase_name or f"{repo.split('/')[-1]}-phase",
         project=repo.split("/")[-1],
         repo=repo,
-        stories=stories,
+        tasks=tasks,
         max_parallel=max_parallel,
     )
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate sprint manifest from Gitea issues"
+        description="Generate phase manifest from Gitea issues"
     )
     parser.add_argument("repo", help="Repository in owner/name format")
-    parser.add_argument("--output", "-o", default="sprint.yaml", help="Output file")
+    parser.add_argument("--output", "-o", default="phase.yaml", help="Output file")
     parser.add_argument("--label", "-l", default="in-sprint", help="Label to filter by")
     parser.add_argument("--milestone", "-m", type=int, help="Milestone ID to filter by")
-    parser.add_argument("--sprint", "-s", help="Sprint name override")
+    parser.add_argument("--phase", "-s", help="Phase name override")
     parser.add_argument("--max-parallel", type=int, default=3, help="Max parallel agents")
 
     args = parser.parse_args()
@@ -147,13 +147,13 @@ def main():
 
     manifest = issues_to_manifest(
         args.repo, issues,
-        sprint_name=args.sprint,
+        phase_name=args.phase,
         max_parallel=args.max_parallel,
     )
 
     output = Path(args.output)
     manifest.to_yaml(output)
-    print(f"Generated {output} with {len(manifest.stories)} stories")
+    print(f"Generated {output} with {len(manifest.tasks)} tasks")
 
 
 if __name__ == "__main__":

--- a/hooks/pretooluse.py
+++ b/hooks/pretooluse.py
@@ -91,7 +91,7 @@ def check_worktree_isolation(command: str) -> dict | None:
             "decision": "allow",
             "systemMessage": (
                 "WARNING: Dev agents should work in worktrees, not the main working tree. "
-                "Use: git worktree add ../.worktrees/{story-id} -b {branch-name}"
+                "Use: git worktree add ../.worktrees/{task-id} -b {branch-name}"
             ),
         }
 

--- a/lib/agent_status.py
+++ b/lib/agent_status.py
@@ -8,7 +8,7 @@ Usage (from hooks or scripts):
     from lib.agent_status import AgentStatus
 
     status = AgentStatus("pm")
-    status.update("working", "Planning sprint 2", repo="tquick/meeting-scribe", issue=17)
+    status.update("working", "Planning phase 2", repo="tquick/meeting-scribe", issue=17)
     status.heartbeat()
     status.clear()
 """

--- a/lib/agent_tx.py
+++ b/lib/agent_tx.py
@@ -7,7 +7,7 @@ Usage:
     from lib.agent_tx import Transaction
 
     tx = Transaction("pm")
-    tx.begin("Implementing rolling summary", "Sprint 1 story #18", repo="tquick/meeting-scribe", issue=18)
+    tx.begin("Implementing rolling summary", "Phase 1 task #18", repo="tquick/meeting-scribe", issue=18)
     tx.action("Created src/summary_prompt.py", "Prompt template for condensed meeting minutes")
     tx.action("Updated pipeline.py", "Integrated summary into batch loop")
     tx.end("success", "Rolling summary working")

--- a/lib/conflict.py
+++ b/lib/conflict.py
@@ -1,14 +1,14 @@
 """Conflict detection via file ownership.
 
-Analyzes a sprint manifest to detect stories that touch the same files.
-Stories with overlapping file ownership must be serialized (not run in
+Analyzes a phase manifest to detect tasks that touch the same files.
+Tasks with overlapping file ownership must be serialized (not run in
 parallel) to prevent merge conflicts.
 
 Usage:
     from lib.conflict import detect_conflicts, apply_serialization
-    from lib.manifest import SprintManifest
+    from lib.manifest import PhaseManifest
 
-    manifest = SprintManifest.from_yaml("sprint.yaml")
+    manifest = PhaseManifest.from_yaml("phase.yaml")
     conflicts = detect_conflicts(manifest)
     if conflicts:
         apply_serialization(manifest, conflicts)
@@ -20,43 +20,43 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Optional
 
-from lib.manifest import SprintManifest
+from lib.manifest import PhaseManifest
 
 
 @dataclass
 class FileConflict:
-    """A conflict where multiple stories touch the same file."""
+    """A conflict where multiple tasks touch the same file."""
 
     file_path: str
-    story_ids: list[str]
+    task_ids: list[str]
 
 
-def build_ownership_map(manifest: SprintManifest) -> dict[str, list[str]]:
-    """Build a map of file -> list of story IDs that touch it."""
+def build_ownership_map(manifest: PhaseManifest) -> dict[str, list[str]]:
+    """Build a map of file -> list of task IDs that touch it."""
     ownership: dict[str, list[str]] = defaultdict(list)
-    for story in manifest.stories:
-        for f in story.files:
-            ownership[f].append(story.id)
+    for task in manifest.tasks:
+        for f in task.files:
+            ownership[f].append(task.id)
     return dict(ownership)
 
 
-def detect_conflicts(manifest: SprintManifest) -> list[FileConflict]:
-    """Find files touched by multiple stories."""
+def detect_conflicts(manifest: PhaseManifest) -> list[FileConflict]:
+    """Find files touched by multiple tasks."""
     ownership = build_ownership_map(manifest)
     conflicts = []
-    for file_path, story_ids in ownership.items():
-        if len(story_ids) > 1:
-            conflicts.append(FileConflict(file_path=file_path, story_ids=story_ids))
+    for file_path, task_ids in ownership.items():
+        if len(task_ids) > 1:
+            conflicts.append(FileConflict(file_path=file_path, task_ids=task_ids))
     return conflicts
 
 
 def apply_serialization(
-    manifest: SprintManifest,
+    manifest: PhaseManifest,
     conflicts: Optional[list[FileConflict]] = None,
 ) -> list[FileConflict]:
-    """Add dependency edges to serialize conflicting stories.
+    """Add dependency edges to serialize conflicting tasks.
 
-    For each conflict, the story with the higher issue number gets a
+    For each conflict, the task with the higher issue number gets a
     dependency on the lower one, ensuring sequential execution.
 
     Returns the conflicts that were resolved.
@@ -67,18 +67,18 @@ def apply_serialization(
     if not conflicts:
         return []
 
-    # Build a lookup for stories
-    story_map = {s.id: s for s in manifest.stories}
+    # Build a lookup for tasks
+    task_map = {s.id: s for s in manifest.tasks}
 
     for conflict in conflicts:
-        # Sort by issue number (or story ID) to get deterministic ordering
+        # Sort by issue number (or task ID) to get deterministic ordering
         sorted_ids = sorted(
-            conflict.story_ids,
-            key=lambda sid: story_map[sid].issue or 0,
+            conflict.task_ids,
+            key=lambda sid: task_map[sid].issue or 0,
         )
-        # Chain them: each story depends on the previous one
+        # Chain them: each task depends on the previous one
         for i in range(1, len(sorted_ids)):
-            later = story_map[sorted_ids[i]]
+            later = task_map[sorted_ids[i]]
             earlier_id = sorted_ids[i - 1]
             if earlier_id not in later.depends_on:
                 later.depends_on.append(earlier_id)
@@ -93,4 +93,4 @@ def print_conflicts(conflicts: list[FileConflict]) -> None:
         return
     print(f"[conflict] {len(conflicts)} file conflict(s) detected:")
     for c in conflicts:
-        print(f"  {c.file_path}: {', '.join(c.story_ids)}")
+        print(f"  {c.file_path}: {', '.join(c.task_ids)}")

--- a/lib/gitea_updates.py
+++ b/lib/gitea_updates.py
@@ -1,16 +1,16 @@
 """Gitea integration for auto-closing issues and posting progress updates.
 
-Called by the dispatcher when stories complete, fail, or during periodic
+Called by the dispatcher when tasks complete, fail, or during periodic
 status updates.
 
 Usage:
     from lib.gitea_updates import GiteaUpdater
 
     updater = GiteaUpdater("tquick/claude-gate")
-    updater.on_story_started(story)
-    updater.on_story_completed(story)
-    updater.on_story_failed(story, "exit code 1")
-    updater.post_sprint_status(manifest, completed, failed)
+    updater.on_task_started(task)
+    updater.on_task_completed(task)
+    updater.on_task_failed(task, "exit code 1")
+    updater.post_phase_status(manifest, completed, failed)
 """
 
 from __future__ import annotations
@@ -20,63 +20,63 @@ from typing import Optional, TYPE_CHECKING
 from lib.gitea_api import GiteaClient
 
 if TYPE_CHECKING:
-    from lib.manifest import SprintManifest, Story
+    from lib.manifest import PhaseManifest, Task
 
 
 class GiteaUpdater:
-    """Posts updates to Gitea issues as stories progress."""
+    """Posts updates to Gitea issues as tasks progress."""
 
     def __init__(self, repo: str, client: Optional[GiteaClient] = None):
         self.repo = repo
         self.client = client or GiteaClient()
 
-    def on_story_started(self, story: Story) -> None:
-        """Post a comment when an agent starts working on a story."""
-        if not story.issue:
+    def on_task_started(self, task: Task) -> None:
+        """Post a comment when an agent starts working on a task."""
+        if not task.issue:
             return
         self.client.add_comment(
             self.repo,
-            story.issue,
-            f"Agent `{story.agent}` has started working on this issue.",
+            task.issue,
+            f"Agent `{task.agent}` has started working on this issue.",
         )
 
-    def on_story_completed(self, story: Story) -> None:
+    def on_task_completed(self, task: Task) -> None:
         """Close the issue and post a completion comment."""
-        if not story.issue:
+        if not task.issue:
             return
         self.client.add_comment(
             self.repo,
-            story.issue,
-            f"Agent `{story.agent}` has completed this issue.",
+            task.issue,
+            f"Agent `{task.agent}` has completed this issue.",
         )
         self.client.patch(
-            f"repos/{self.repo}/issues/{story.issue}",
+            f"repos/{self.repo}/issues/{task.issue}",
             {"state": "closed"},
         )
 
-    def on_story_failed(self, story: Story, reason: str = "") -> None:
+    def on_task_failed(self, task: Task, reason: str = "") -> None:
         """Post a failure comment (don't close the issue)."""
-        if not story.issue:
+        if not task.issue:
             return
-        msg = f"Agent `{story.agent}` failed on this issue."
+        msg = f"Agent `{task.agent}` failed on this issue."
         if reason:
             msg += f"\n\nReason: {reason}"
-        self.client.add_comment(self.repo, story.issue, msg)
+        self.client.add_comment(self.repo, task.issue, msg)
 
-    def post_sprint_status(
+    def post_phase_status(
         self,
-        manifest: SprintManifest,
+        manifest: PhaseManifest,
         completed: set[str],
         failed: set[str],
     ) -> None:
-        """Post a sprint summary comment to all open issues in the sprint."""
-        total = len(manifest.stories)
+        """Post a phase summary comment to all open issues in the phase."""
+        total = len(manifest.tasks)
         done = len(completed)
         fail = len(failed)
         remaining = total - done - fail
 
         lines = [
-            f"## Sprint Status: {manifest.sprint}",
+            f"## Phase Status: {manifest.phase}",
             f"- Completed: {done}/{total}",
         ]
         if fail:
@@ -84,20 +84,20 @@ class GiteaUpdater:
         if remaining:
             lines.append(f"- Remaining: {remaining}")
 
-        lines.append("\n| Story | Status |")
+        lines.append("\n| Task | Status |")
         lines.append("|-------|--------|")
-        for story in manifest.stories:
-            if story.id in completed:
+        for task in manifest.tasks:
+            if task.id in completed:
                 status = "Done"
-            elif story.id in failed:
+            elif task.id in failed:
                 status = "Failed"
             else:
                 status = "Pending"
-            lines.append(f"| {story.id}: {story.title} | {status} |")
+            lines.append(f"| {task.id}: {task.title} | {status} |")
 
         body = "\n".join(lines)
 
         # Post to each issue that's still open (failed or pending)
-        for story in manifest.stories:
-            if story.issue and story.id not in completed:
-                self.client.add_comment(self.repo, story.issue, body)
+        for task in manifest.tasks:
+            if task.issue and task.id not in completed:
+                self.client.add_comment(self.repo, task.issue, body)

--- a/lib/manifest.py
+++ b/lib/manifest.py
@@ -1,14 +1,14 @@
-"""Sprint manifest parser and data model.
+"""Phase manifest parser and data model.
 
-Defines the YAML format for automated sprint dispatch. The manifest is the
+Defines the YAML format for automated phase dispatch. The manifest is the
 contract between the PM (who plans) and the dispatcher (who executes).
 
 Usage:
-    from lib.manifest import SprintManifest
+    from lib.manifest import PhaseManifest
 
-    manifest = SprintManifest.from_yaml("sprint.yaml")
-    for story in manifest.stories:
-        print(f"{story.id}: {story.title} -> {story.agent}")
+    manifest = PhaseManifest.from_yaml("phase.yaml")
+    for task in manifest.tasks:
+        print(f"{task.id}: {task.title} -> {task.agent}")
 """
 
 from __future__ import annotations
@@ -20,8 +20,8 @@ from typing import Optional
 
 
 @dataclass
-class Story:
-    """A single work item in the sprint."""
+class Task:
+    """A single work item in the phase."""
 
     id: str
     title: str
@@ -36,30 +36,30 @@ class Story:
 
 
 @dataclass
-class SprintManifest:
-    """Complete sprint manifest parsed from YAML."""
+class PhaseManifest:
+    """Complete phase manifest parsed from YAML."""
 
-    sprint: str
+    phase: str
     project: str
     repo: str
-    stories: list[Story]
+    tasks: list[Task]
     worktree_branch: str = ""
     max_parallel: int = 3
 
     @classmethod
-    def from_yaml(cls, path: str | Path) -> SprintManifest:
-        """Parse a sprint manifest from a YAML file."""
+    def from_yaml(cls, path: str | Path) -> PhaseManifest:
+        """Parse a phase manifest from a YAML file."""
         path = Path(path)
         with open(path) as f:
             data = yaml.safe_load(f)
 
-        if not data or "sprint" not in data:
-            raise ValueError(f"Invalid manifest: missing 'sprint' key in {path}")
+        if not data or "phase" not in data:
+            raise ValueError(f"Invalid manifest: missing 'phase' key in {path}")
 
-        stories = []
-        for s in data.get("stories", []):
-            stories.append(
-                Story(
+        tasks = []
+        for s in data.get("tasks", []):
+            tasks.append(
+                Task(
                     id=s["id"],
                     title=s["title"],
                     agent=s["agent"],
@@ -74,10 +74,10 @@ class SprintManifest:
             )
 
         return cls(
-            sprint=data["sprint"],
+            phase=data["phase"],
             project=data.get("project", ""),
             repo=data.get("repo", ""),
-            stories=stories,
+            tasks=tasks,
             worktree_branch=data.get("worktree_branch", ""),
             max_parallel=data.get("max_parallel", 3),
         )
@@ -85,15 +85,15 @@ class SprintManifest:
     def to_yaml(self, path: str | Path) -> None:
         """Write the manifest to a YAML file."""
         data = {
-            "sprint": self.sprint,
+            "phase": self.phase,
             "project": self.project,
             "repo": self.repo,
             "worktree_branch": self.worktree_branch,
             "max_parallel": self.max_parallel,
-            "stories": [],
+            "tasks": [],
         }
-        for s in self.stories:
-            story_data: dict = {
+        for s in self.tasks:
+            task_data: dict = {
                 "id": s.id,
                 "title": s.title,
                 "agent": s.agent,
@@ -102,38 +102,38 @@ class SprintManifest:
                 "prompt": s.prompt,
             }
             if s.depends_on:
-                story_data["depends_on"] = s.depends_on
+                task_data["depends_on"] = s.depends_on
             if s.files:
-                story_data["files"] = s.files
+                task_data["files"] = s.files
             if s.labels:
-                story_data["labels"] = s.labels
+                task_data["labels"] = s.labels
             if s.priority:
-                story_data["priority"] = s.priority
-            data["stories"].append(story_data)
+                task_data["priority"] = s.priority
+            data["tasks"].append(task_data)
 
         path = Path(path)
         with open(path, "w") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
-    def get_story(self, story_id: str) -> Optional[Story]:
-        """Find a story by ID."""
-        for s in self.stories:
-            if s.id == story_id:
+    def get_task(self, task_id: str) -> Optional[Task]:
+        """Find a task by ID."""
+        for s in self.tasks:
+            if s.id == task_id:
                 return s
         return None
 
-    def dependency_order(self) -> list[list[Story]]:
-        """Return stories grouped into dependency layers.
+    def dependency_order(self) -> list[list[Task]]:
+        """Return tasks grouped into dependency layers.
 
-        Each layer contains stories that can run in parallel (all deps satisfied
+        Each layer contains tasks that can run in parallel (all deps satisfied
         by previous layers). This is a topological sort by layers.
         """
         completed: set[str] = set()
-        remaining = {s.id: s for s in self.stories}
-        layers: list[list[Story]] = []
+        remaining = {s.id: s for s in self.tasks}
+        layers: list[list[Task]] = []
 
         while remaining:
-            # Find stories whose deps are all completed
+            # Find tasks whose deps are all completed
             ready = [
                 s for s in remaining.values()
                 if all(d in completed for d in s.depends_on)

--- a/lib/monitor.py
+++ b/lib/monitor.py
@@ -33,7 +33,7 @@ PROCESS_DEAD_GRACE_SEC = 30  # grace period after process death before flagging
 class HealthIssue:
     """A detected health problem with an agent."""
 
-    story_id: str
+    task_id: str
     agent_name: str
     issue_type: str  # stale_heartbeat | process_dead | no_status_file
     message: str
@@ -59,31 +59,31 @@ class HealthMonitor:
         issues: list[HealthIssue] = []
         now = datetime.datetime.now(datetime.timezone.utc)
 
-        for story_id, ap in self.dispatcher.agents.items():
+        for task_id, ap in self.dispatcher.agents.items():
             if ap.state != "running":
                 continue
 
-            story_issues = self._check_agent(story_id, ap, now)
-            issues.extend(story_issues)
+            task_issues = self._check_agent(task_id, ap, now)
+            issues.extend(task_issues)
 
         return issues
 
     def _check_agent(
         self,
-        story_id: str,
+        task_id: str,
         ap: AgentProcess,
         now: datetime.datetime,
     ) -> list[HealthIssue]:
         """Check a single agent's health."""
         issues: list[HealthIssue] = []
-        agent_name = ap.story.agent
+        agent_name = ap.task.agent
 
         # Check if process is still alive
         if ap.process is not None and ap.process.poll() is not None:
             exit_code = ap.process.returncode
             if exit_code != 0:
                 issues.append(HealthIssue(
-                    story_id=story_id,
+                    story_id=task_id,
                     agent_name=agent_name,
                     issue_type="process_dead",
                     message=f"Process exited with code {exit_code}",
@@ -95,7 +95,7 @@ class HealthMonitor:
         status_file = os.path.join(STATUS_DIR, f"{agent_name}.json")
         if not os.path.exists(status_file):
             issues.append(HealthIssue(
-                story_id=story_id,
+                story_id=task_id,
                 agent_name=agent_name,
                 issue_type="no_status_file",
                 message="No status file found",
@@ -111,7 +111,7 @@ class HealthMonitor:
                 age_sec = (now - hb_dt).total_seconds()
                 if age_sec > self.stale_threshold:
                     issues.append(HealthIssue(
-                        story_id=story_id,
+                        story_id=task_id,
                         agent_name=agent_name,
                         issue_type="stale_heartbeat",
                         message=f"Heartbeat stale for {int(age_sec)}s (threshold: {self.stale_threshold}s)",
@@ -125,24 +125,24 @@ class HealthMonitor:
 
         Returns True if recovery was attempted.
         """
-        story_id = issue.story_id
-        retry_count = self.retry_counts.get(story_id, 0)
+        task_id = issue.task_id
+        retry_count = self.retry_counts.get(task_id, 0)
 
         if retry_count >= self.max_retries:
-            print(f"[monitor] {story_id}: max retries ({self.max_retries}) exceeded, marking failed")
-            ap = self.dispatcher.agents.get(story_id)
+            print(f"[monitor] {task_id}: max retries ({self.max_retries}) exceeded, marking failed")
+            ap = self.dispatcher.agents.get(task_id)
             if ap:
                 ap.state = "failed"
-                self.dispatcher.failed.add(story_id)
+                self.dispatcher.failed.add(task_id)
             return False
 
         if issue.issue_type == "process_dead":
-            print(f"[monitor] {story_id}: restarting (attempt {retry_count + 1}/{self.max_retries})")
-            ap = self.dispatcher.agents.get(story_id)
+            print(f"[monitor] {task_id}: restarting (attempt {retry_count + 1}/{self.max_retries})")
+            ap = self.dispatcher.agents.get(task_id)
             if ap:
-                new_ap = self.dispatcher._spawn_agent(ap.story)
-                self.dispatcher.agents[story_id] = new_ap
-                self.retry_counts[story_id] = retry_count + 1
+                new_ap = self.dispatcher._spawn_agent(ap.task)
+                self.dispatcher.agents[task_id] = new_ap
+                self.retry_counts[task_id] = retry_count + 1
                 return True
 
         return False
@@ -156,4 +156,4 @@ def print_health_report(issues: list[HealthIssue]) -> None:
     print(f"[monitor] {len(issues)} health issue(s):")
     for issue in issues:
         icon = "!!" if issue.severity == "critical" else "  "
-        print(f"  {icon} {issue.story_id} ({issue.agent_name}): {issue.issue_type} — {issue.message}")
+        print(f"  {icon} {issue.task_id} ({issue.agent_name}): {issue.issue_type} — {issue.message}")

--- a/scoreboard.md
+++ b/scoreboard.md
@@ -1,0 +1,20 @@
+# Phase Scoreboard: multi-agent-smoke-test
+_Updated: 2026-03-10 13:58:41_
+
+**Total:** 3 tasks | **Done:** 3 | **Failed:** 0 | **Running:** 0 | **Pending:** 0
+
+## Agent Leaderboard
+
+| Agent | Done | Running | Failed | Pending |
+|-------|------|---------|--------|---------|
+| agent-alpha | 1 | 0 | 0 | 0 |
+| agent-beta | 1 | 0 | 0 | 0 |
+| agent-gamma | 1 | 0 | 0 | 0 |
+
+## Tasks
+
+| Task | Repo | Agent | Status |
+|-------|------|-------|--------|
+| multi#1: Parallel agent A | wasteland-orchestrator | agent-alpha | Done |
+| multi#2: Parallel agent B | wasteland-orchestrator | agent-beta | Done |
+| multi#3: Sequential agent C (depends on A and B) | wasteland-orchestrator | agent-gamma | Done |

--- a/skills/agent-protocol/SKILL.md
+++ b/skills/agent-protocol/SKILL.md
@@ -82,7 +82,7 @@ gitea_create_issue "tquick/meeting-scribe" "Issue title" "Issue body" "1,2,3"
 All dev work MUST happen in worktrees:
 
 ```bash
-# Create worktree for a story
+# Create worktree for a task
 git worktree add ../.worktrees/issue-17-assistant-skeleton -b feat/issue-17-assistant-skeleton
 
 # Work in the worktree
@@ -106,7 +106,7 @@ source ~/.claude/lib/agent-tx.sh
 ### Usage
 ```bash
 # Start a transaction — state your intent and justify it
-tx_begin "Implementing rolling summary" "Sprint 1 story #18" "tquick/meeting-scribe" 18
+tx_begin "Implementing rolling summary" "Phase 1 task #18" "tquick/meeting-scribe" 18
 
 # Log each significant action with what + why
 tx_action "Created src/summary_prompt.py" "Prompt template for condensed meeting minutes"
@@ -124,7 +124,7 @@ tx_end "success" "Rolling summary working, broadcasts every 2 minutes"
 
 ### What Makes a Good Transaction
 - **Intent**: Human-readable, high-level ("Implementing rolling summary" not "editing files")
-- **Justification**: Why this is being done now ("Sprint 1 story #18")
+- **Justification**: Why this is being done now ("Phase 1 task #18")
 - **Actions**: Describe what changed and why, not tool-level details
   - Good: `tx_action "Added Ollama health check" "Startup should fail gracefully if Ollama is down"`
   - Bad: `tx_action "Edited main.py line 42" "Changed code"`

--- a/swarm.py
+++ b/swarm.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """Swarm dispatcher — the brain of the orchestrator.
 
-Reads a sprint manifest, builds a dependency DAG, spawns `claude -p` agents
+Reads a phase manifest, builds a dependency DAG, spawns `claude -p` agents
 in worktrees, and monitors their progress via status files.
 
 Usage:
-    python3 swarm.py sprint.yaml                # Launch the swarm
-    python3 swarm.py sprint.yaml --dry-run      # Show execution plan
+    python3 swarm.py phase.yaml                # Launch the swarm
+    python3 swarm.py phase.yaml --dry-run      # Show execution plan
     python3 swarm.py --status                   # Show running agents
 """
 
@@ -25,7 +25,7 @@ from typing import Optional
 
 from lib.agent_status import AgentStatus, list_agents
 from lib.conflict import detect_conflicts, apply_serialization, print_conflicts
-from lib.manifest import SprintManifest, Story
+from lib.manifest import PhaseManifest, Task
 from lib.gitea_updates import GiteaUpdater
 from lib.monitor import HealthMonitor, print_health_report
 
@@ -50,7 +50,7 @@ REPO_PATHS: dict[str, str] = {
 class AgentProcess:
     """Tracks a running claude -p agent."""
 
-    story: Story
+    task: Task
     process: Optional[subprocess.Popen] = None
     pid: Optional[int] = None
     state: str = "pending"  # pending | running | done | failed
@@ -59,9 +59,9 @@ class AgentProcess:
 
 
 class Dispatcher:
-    """Spawns and manages agent processes from a sprint manifest."""
+    """Spawns and manages agent processes from a phase manifest."""
 
-    def __init__(self, manifest: SprintManifest, dry_run: bool = False):
+    def __init__(self, manifest: PhaseManifest, dry_run: bool = False):
         self.manifest = manifest
         self.dry_run = dry_run
         self.agents: dict[str, AgentProcess] = {}
@@ -71,7 +71,7 @@ class Dispatcher:
 
         # Multi-repo: create per-repo updaters
         self._gitea_updaters: dict[str, GiteaUpdater] = {}
-        repos = set(s.repo for s in manifest.stories if s.repo)
+        repos = set(s.repo for s in manifest.tasks if s.repo)
         for repo in repos:
             self._gitea_updaters[repo] = GiteaUpdater(repo)
         # Legacy single-repo fallback
@@ -89,36 +89,36 @@ class Dispatcher:
 
     def _kill_all(self) -> None:
         """Terminate all running agent processes."""
-        for story_id, ap in self.agents.items():
+        for task_id, ap in self.agents.items():
             if ap.process and ap.process.poll() is None:
-                print(f"[swarm] Terminating {story_id} (PID {ap.pid})")
+                print(f"[swarm] Terminating {task_id} (PID {ap.pid})")
                 ap.process.terminate()
                 try:
                     ap.process.wait(timeout=5)
                 except subprocess.TimeoutExpired:
                     ap.process.kill()
 
-    def _resolve_repo_path(self, story: Story) -> str:
-        """Resolve the local filesystem path for a story's repository."""
-        return REPO_PATHS.get(story.repo, os.path.expanduser(f"~/projects/{story.repo.split('/')[-1]}"))
+    def _resolve_repo_path(self, task: Task) -> str:
+        """Resolve the local filesystem path for a task's repository."""
+        return REPO_PATHS.get(task.repo, os.path.expanduser(f"~/projects/{task.repo.split('/')[-1]}"))
 
-    def _build_prompt(self, story: Story) -> str:
+    def _build_prompt(self, task: Task) -> str:
         """Build the prompt for a claude -p agent with worktree and PR instructions."""
-        repo_path = self._resolve_repo_path(story)
-        branch_name = f"feat/issue-{story.issue}-{story.title.lower()[:30].replace(' ', '-').rstrip('-')}"
+        repo_path = self._resolve_repo_path(task)
+        branch_name = f"feat/issue-{task.issue}-{task.title.lower()[:30].replace(' ', '-').rstrip('-')}"
         worktree_dir = f"{repo_path}/.worktrees/{branch_name}"
 
         parts = [
-            f"You are agent '{story.agent}' working on: {story.title}",
-            f"Repository: {story.repo}",
+            f"You are agent '{task.agent}' working on: {task.title}",
+            f"Repository: {task.repo}",
             f"Local repo path: {repo_path}",
         ]
-        if story.issue:
-            parts.append(f"Gitea issue: #{story.issue}")
-        if story.files:
-            parts.append(f"Key files: {', '.join(story.files)}")
-        if story.prompt:
-            parts.append(f"\nTask details:\n{story.prompt}")
+        if task.issue:
+            parts.append(f"Gitea issue: #{task.issue}")
+        if task.files:
+            parts.append(f"Key files: {', '.join(task.files)}")
+        if task.prompt:
+            parts.append(f"\nTask details:\n{task.prompt}")
 
         parts.append(f"""
 
@@ -145,16 +145,16 @@ Update or create CHANGELOG.md in Keep a Changelog format. Add your changes under
 git add -A
 git commit -m "feat: <description>
 
-Closes #{story.issue}
+Closes #{task.issue}
 
-Co-Authored-By: {story.agent} <{story.agent}@wasteland.dev>"
+Co-Authored-By: {task.agent} <{task.agent}@wasteland.dev>"
 git push -u origin {branch_name}
 ```
 
 ### 5. Create Pull Request
 Create a PR using gh or the Gitea API. The PR title should reference the issue.
 ```bash
-gh pr create --repo {story.repo} --title "feat: {story.title}" --body "Closes #{story.issue}
+gh pr create --repo {task.repo} --title "feat: {task.title}" --body "Closes #{task.issue}
 
 ## Summary
 <describe changes>
@@ -162,19 +162,19 @@ gh pr create --repo {story.repo} --title "feat: {story.title}" --body "Closes #{
 ## Test Plan
 <how to verify>
 
-Agent: {story.agent} | Sprint: {self.manifest.sprint}"
+Agent: {task.agent} | Phase: {self.manifest.phase}"
 ```
 If gh doesn't work with Gitea, use curl with the Gitea API:
 ```bash
 source ~/.claude/lib/gitea-api.sh
-gitea_post "repos/{story.repo}/pulls" '{{"title":"feat: {story.title}","head":"{branch_name}","base":"main","body":"Closes #{story.issue}\\n\\nAgent: {story.agent}"}}'
+gitea_post "repos/{task.repo}/pulls" '{{"title":"feat: {task.title}","head":"{branch_name}","base":"main","body":"Closes #{task.issue}\\n\\nAgent: {task.agent}"}}'
 ```
 
 ### 6. Request Review
 After creating the PR, add a comment mentioning @claude for automated review:
 ```bash
 # If the repo has claude-review action, it triggers on @claude mention
-gitea_post "repos/{story.repo}/issues/<PR_NUMBER>/comments" '{{"body":"@claude please review this PR"}}'
+gitea_post "repos/{task.repo}/issues/<PR_NUMBER>/comments" '{{"body":"@claude please review this PR"}}'
 ```
 
 ### 7. Agent Protocol
@@ -182,49 +182,49 @@ gitea_post "repos/{story.repo}/issues/<PR_NUMBER>/comments" '{{"body":"@claude p
 source ~/.claude/lib/agent-status.sh
 source ~/.claude/lib/gitea-api.sh
 source ~/.claude/lib/agent-tx.sh
-export CLAUDE_AGENT_NAME={story.agent}
-agent_status_update "working" "{story.title}" "{story.repo}" {story.issue or 0}
-tx_begin "{story.title}" "Sprint: {self.manifest.sprint}, Issue #{story.issue}" "{story.repo}" {story.issue or 0}
+export CLAUDE_AGENT_NAME={task.agent}
+agent_status_update "working" "{task.title}" "{task.repo}" {task.issue or 0}
+tx_begin "{task.title}" "Phase: {self.manifest.phase}, Issue #{task.issue}" "{task.repo}" {task.issue or 0}
 ```
 When done:
 ```bash
 tx_end "success" "Brief summary of what was done"
-agent_status_update "idle" "Completed {story.id}"
+agent_status_update "idle" "Completed {task.id}"
 ```
 """)
         return "\n".join(parts)
 
-    def _get_updater(self, story: Story) -> Optional[GiteaUpdater]:
-        """Get the Gitea updater for a story's repo."""
-        return self._gitea_updaters.get(story.repo) or self.gitea
+    def _get_updater(self, task: Task) -> Optional[GiteaUpdater]:
+        """Get the Gitea updater for a task's repo."""
+        return self._gitea_updaters.get(task.repo) or self.gitea
 
-    def _spawn_agent(self, story: Story) -> AgentProcess:
-        """Spawn a single claude -p agent in the story's repo directory."""
-        prompt = self._build_prompt(story)
+    def _spawn_agent(self, task: Task) -> AgentProcess:
+        """Spawn a single claude -p agent in the task's repo directory."""
+        prompt = self._build_prompt(task)
         output_dir = Path("logs")
         output_dir.mkdir(exist_ok=True)
-        output_file = str(output_dir / f"{story.id.replace('#', '')}-{story.agent}.log")
+        output_file = str(output_dir / f"{task.id.replace('#', '')}-{task.agent}.log")
 
-        repo_path = self._resolve_repo_path(story)
+        repo_path = self._resolve_repo_path(task)
         cmd = [
             CLAUDE_BIN, "-p", prompt,
             "--output-format", "text",
             "--dangerously-skip-permissions",
         ]
 
-        print(f"[swarm] Spawning {story.agent} for {story.id}: {story.title}")
-        print(f"[swarm]   repo: {story.repo} -> {repo_path}")
+        print(f"[swarm] Spawning {task.agent} for {task.id}: {task.title}")
+        print(f"[swarm]   repo: {task.repo} -> {repo_path}")
 
-        updater = self._get_updater(story)
+        updater = self._get_updater(task)
         if updater and not self.dry_run:
             try:
-                updater.on_story_started(story)
+                updater.on_task_started(task)
             except Exception as e:
                 print(f"[swarm] Warning: Gitea update failed: {e}")
 
         if self.dry_run:
             print(f"[swarm]   DRY RUN: would run: claude -p '<prompt>' > {output_file}")
-            return AgentProcess(story=story, state="done")
+            return AgentProcess(task=task, state="done")
 
         # Strip CLAUDECODE env var so nested claude -p sessions can launch
         # Ensure node is on PATH (nvm may not be sourced in subprocess)
@@ -251,7 +251,7 @@ agent_status_update "idle" "Completed {story.id}"
             )
 
         ap = AgentProcess(
-            story=story,
+            task=task,
             process=proc,
             pid=proc.pid,
             state="running",
@@ -263,32 +263,32 @@ agent_status_update "idle" "Completed {story.id}"
 
         return ap
 
-    def _check_agent(self, story_id: str) -> None:
+    def _check_agent(self, task_id: str) -> None:
         """Check if an agent process has completed."""
-        ap = self.agents[story_id]
+        ap = self.agents[task_id]
         if ap.state != "running" or ap.process is None:
             return
 
         ret = ap.process.poll()
         if ret is not None:
             ap.exit_code = ret
-            updater = self._get_updater(ap.story)
+            updater = self._get_updater(ap.task)
             if ret == 0:
                 ap.state = "done"
-                self.completed.add(story_id)
-                print(f"[swarm] {story_id} completed successfully")
+                self.completed.add(task_id)
+                print(f"[swarm] {task_id} completed successfully")
                 if updater:
                     try:
-                        updater.on_story_completed(ap.story)
+                        updater.on_task_completed(ap.task)
                     except Exception as e:
                         print(f"[swarm] Warning: Gitea close failed: {e}")
             else:
                 ap.state = "failed"
-                self.failed.add(story_id)
-                print(f"[swarm] {story_id} FAILED (exit code {ret})")
+                self.failed.add(task_id)
+                print(f"[swarm] {task_id} FAILED (exit code {ret})")
                 if updater:
                     try:
-                        updater.on_story_failed(ap.story, f"exit code {ret}")
+                        updater.on_task_failed(ap.task, f"exit code {ret}")
                     except Exception as e:
                         print(f"[swarm] Warning: Gitea update failed: {e}")
             self._update_scoreboard()
@@ -298,33 +298,33 @@ agent_status_update "idle" "Completed {story.id}"
         from datetime import datetime
 
         lines = [
-            f"# Sprint Scoreboard: {self.manifest.sprint}",
+            f"# Phase Scoreboard: {self.manifest.phase}",
             f"_Updated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}_\n",
-            f"**Total:** {len(self.manifest.stories)} stories | "
+            f"**Total:** {len(self.manifest.tasks)} tasks | "
             f"**Done:** {len(self.completed)} | "
             f"**Failed:** {len(self.failed)} | "
             f"**Running:** {self._running_count()} | "
-            f"**Pending:** {len(self.manifest.stories) - len(self.completed) - len(self.failed) - self._running_count()}\n",
+            f"**Pending:** {len(self.manifest.tasks) - len(self.completed) - len(self.failed) - self._running_count()}\n",
         ]
 
         # Agent leaderboard
         agent_stats: dict[str, dict] = {}
-        for story in self.manifest.stories:
-            if story.agent not in agent_stats:
-                agent_stats[story.agent] = {"done": 0, "failed": 0, "running": 0, "pending": 0, "stories": []}
+        for task in self.manifest.tasks:
+            if task.agent not in agent_stats:
+                agent_stats[task.agent] = {"done": 0, "failed": 0, "running": 0, "pending": 0, "tasks": []}
             state = "pending"
-            if story.id in self.completed:
+            if task.id in self.completed:
                 state = "done"
-                agent_stats[story.agent]["done"] += 1
-            elif story.id in self.failed:
+                agent_stats[task.agent]["done"] += 1
+            elif task.id in self.failed:
                 state = "failed"
-                agent_stats[story.agent]["failed"] += 1
-            elif story.id in self.agents and self.agents[story.id].state == "running":
+                agent_stats[task.agent]["failed"] += 1
+            elif task.id in self.agents and self.agents[task.id].state == "running":
                 state = "running"
-                agent_stats[story.agent]["running"] += 1
+                agent_stats[task.agent]["running"] += 1
             else:
-                agent_stats[story.agent]["pending"] += 1
-            agent_stats[story.agent]["stories"].append((story, state))
+                agent_stats[task.agent]["pending"] += 1
+            agent_stats[task.agent]["tasks"].append((task, state))
 
         lines.append("## Agent Leaderboard\n")
         lines.append("| Agent | Done | Running | Failed | Pending |")
@@ -332,35 +332,35 @@ agent_status_update "idle" "Completed {story.id}"
         for agent, stats in sorted(agent_stats.items(), key=lambda x: -x[1]["done"]):
             lines.append(f"| {agent} | {stats['done']} | {stats['running']} | {stats['failed']} | {stats['pending']} |")
 
-        lines.append("\n## Stories\n")
-        lines.append("| Story | Repo | Agent | Status |")
+        lines.append("\n## Tasks\n")
+        lines.append("| Task | Repo | Agent | Status |")
         lines.append("|-------|------|-------|--------|")
-        for story in self.manifest.stories:
-            if story.id in self.completed:
+        for task in self.manifest.tasks:
+            if task.id in self.completed:
                 status = "Done"
-            elif story.id in self.failed:
+            elif task.id in self.failed:
                 status = "FAILED"
-            elif story.id in self.agents and self.agents[story.id].state == "running":
+            elif task.id in self.agents and self.agents[task.id].state == "running":
                 status = "Running..."
             else:
                 status = "Pending"
-            repo_short = story.repo.split("/")[-1] if story.repo else ""
-            lines.append(f"| {story.id}: {story.title[:50]} | {repo_short} | {story.agent} | {status} |")
+            repo_short = task.repo.split("/")[-1] if task.repo else ""
+            lines.append(f"| {task.id}: {task.title[:50]} | {repo_short} | {task.agent} | {status} |")
 
         Path(SCOREBOARD_FILE).write_text("\n".join(lines) + "\n")
 
-    def _ready_stories(self) -> list[Story]:
-        """Find stories whose dependencies are met and haven't started."""
+    def _ready_tasks(self) -> list[Task]:
+        """Find tasks whose dependencies are met and haven't started."""
         started = set(self.agents.keys())
         ready = []
-        for story in self.manifest.stories:
-            if story.id in started:
+        for task in self.manifest.tasks:
+            if task.id in started:
                 continue
-            if story.id in self.failed:
+            if task.id in self.failed:
                 continue
             # Check all deps are completed
-            if all(d in self.completed for d in story.depends_on):
-                ready.append(story)
+            if all(d in self.completed for d in task.depends_on):
+                ready.append(task)
         return ready
 
     def _running_count(self) -> int:
@@ -368,12 +368,12 @@ agent_status_update "idle" "Completed {story.id}"
         return sum(1 for ap in self.agents.values() if ap.state == "running")
 
     def run(self) -> bool:
-        """Execute the full sprint dispatch loop.
+        """Execute the full phase dispatch loop.
 
-        Returns True if all stories completed successfully.
+        Returns True if all tasks completed successfully.
         """
-        print(f"[swarm] Starting sprint: {self.manifest.sprint}")
-        print(f"[swarm] {len(self.manifest.stories)} stories, max {self.manifest.max_parallel} parallel")
+        print(f"[swarm] Starting phase: {self.manifest.phase}")
+        print(f"[swarm] {len(self.manifest.tasks)} tasks, max {self.manifest.max_parallel} parallel")
 
         # Detect and resolve file ownership conflicts
         conflicts = detect_conflicts(self.manifest)
@@ -391,10 +391,10 @@ agent_status_update "idle" "Completed {story.id}"
                     print(f"  {s.id}: {s.title} -> {s.agent}{deps}")
             print("\n[swarm] === End Plan ===")
             # Still spawn in dry-run to show what would happen
-            for story in self.manifest.stories:
-                ap = self._spawn_agent(story)
-                self.agents[story.id] = ap
-                self.completed.add(story.id)
+            for task in self.manifest.tasks:
+                ap = self._spawn_agent(task)
+                self.agents[task.id] = ap
+                self.completed.add(task.id)
             return True
 
         health_monitor = HealthMonitor(self)
@@ -402,8 +402,8 @@ agent_status_update "idle" "Completed {story.id}"
 
         while not self._shutdown:
             # Check running agents
-            for story_id in list(self.agents.keys()):
-                self._check_agent(story_id)
+            for task_id in list(self.agents.keys()):
+                self._check_agent(task_id)
 
             # Periodic health monitoring (every 3rd poll)
             health_check_counter += 1
@@ -416,43 +416,43 @@ agent_status_update "idle" "Completed {story.id}"
                             health_monitor.attempt_recovery(issue)
 
             # Check if we're done
-            total = len(self.manifest.stories)
+            total = len(self.manifest.tasks)
             done = len(self.completed) + len(self.failed)
             if done >= total:
                 break
 
-            # Spawn ready stories up to max_parallel
-            ready = self._ready_stories()
+            # Spawn ready tasks up to max_parallel
+            ready = self._ready_tasks()
             running = self._running_count()
             slots = self.manifest.max_parallel - running
 
-            for story in ready[:slots]:
-                ap = self._spawn_agent(story)
-                self.agents[story.id] = ap
+            for task in ready[:slots]:
+                ap = self._spawn_agent(task)
+                self.agents[task.id] = ap
 
             time.sleep(POLL_INTERVAL)
 
         # Final summary
-        print(f"\n[swarm] === Sprint Summary ===")
-        print(f"  Completed: {len(self.completed)}/{len(self.manifest.stories)}")
+        print(f"\n[swarm] === Phase Summary ===")
+        print(f"  Completed: {len(self.completed)}/{len(self.manifest.tasks)}")
         if self.failed:
             print(f"  Failed: {', '.join(self.failed)}")
-        for story_id, ap in self.agents.items():
+        for task_id, ap in self.agents.items():
             status = "OK" if ap.state == "done" else ap.state.upper()
-            print(f"  {story_id}: {ap.story.title} [{status}]")
+            print(f"  {task_id}: {ap.task.title} [{status}]")
 
         # Final scoreboard
         self._update_scoreboard()
         print(f"  Scoreboard: {SCOREBOARD_FILE}")
 
-        # Post final sprint status to Gitea (per-repo)
+        # Post final phase status to Gitea (per-repo)
         if not self.dry_run:
             for repo, updater in self._gitea_updaters.items():
                 try:
-                    # Filter manifest to this repo's stories for the status post
-                    updater.post_sprint_status(self.manifest, self.completed, self.failed)
+                    # Filter manifest to this repo's tasks for the status post
+                    updater.post_phase_status(self.manifest, self.completed, self.failed)
                 except Exception as e:
-                    print(f"[swarm] Warning: Gitea sprint status for {repo} failed: {e}")
+                    print(f"[swarm] Warning: Gitea phase status for {repo} failed: {e}")
 
         return len(self.failed) == 0 and not self._shutdown
 
@@ -472,8 +472,8 @@ def show_status() -> None:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Swarm dispatcher for sprint execution")
-    parser.add_argument("manifest", nargs="?", help="Path to sprint.yaml manifest")
+    parser = argparse.ArgumentParser(description="Swarm dispatcher for phase execution")
+    parser.add_argument("manifest", nargs="?", help="Path to phase.yaml manifest")
     parser.add_argument("--status", action="store_true", help="Show current agent statuses")
     parser.add_argument("--dry-run", action="store_true", help="Show execution plan without spawning")
 
@@ -486,7 +486,7 @@ def main():
     if not args.manifest:
         parser.error("manifest file required (or use --status)")
 
-    manifest = SprintManifest.from_yaml(args.manifest)
+    manifest = PhaseManifest.from_yaml(args.manifest)
     dispatcher = Dispatcher(manifest, dry_run=args.dry_run)
     success = dispatcher.run()
     sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
- Renamed `SprintManifest` → `PhaseManifest`, `Story` → `Task` across all Python modules
- Updated all variable names, method names, docstrings, and comments (e.g. `on_story_started` → `on_task_started`, `_ready_stories` → `_ready_tasks`)
- Updated YAML keys: `sprint` → `phase`, `stories` → `tasks`
- Updated CLI args: `--sprint` → `--phase`, default output `sprint.yaml` → `phase.yaml`
- Updated all `.md` docs: README, SKILL.md, commands, design doc, scoreboard
- Preserved `in-sprint` Gitea label references (those are live labels, not terminology)
- Preserved vocabulary.md's definition table (intentionally shows old→new mappings)

**16 files changed, 429 insertions, 269 deletions**

Closes tquick/wasteland-orchestrator#52 (Gitea)

## Test plan
- [ ] Verify `python3 -c "import ast; ast.parse(open(f).read())"` passes for all .py files (done pre-commit)
- [ ] Verify no remaining `SprintManifest`, `Story` class, or `sprint` variable references (except `in-sprint` label)
- [ ] Verify `swarm.py` still parses correctly with a phase.yaml manifest
- [ ] Grep for stale references: `rg '\bstory\b|\bSprint\b' --type py` should return nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)