### PR TITLE
fix: add verification step to claude-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,21 +3,9 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,6 +27,3 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,4 +40,3 @@ jobs:
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,3 +40,4 @@ jobs:
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   claude-review:
@@ -19,6 +19,15 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Record pre-review comment count
+        id: pre-count
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          count=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate --jq 'length')
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+          echo "Pre-review comment count: ${count}"
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -28,15 +37,35 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request and provide feedback on:
+            Review this pull request. You MUST leave at least one comment on the PR using `gh pr comment`.
+
+            Review criteria:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
             - Security concerns
             - Test coverage
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            Use the repository's CLAUDE.md for guidance on style and conventions.
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            Format your review as a single comment with:
+            1. A summary line (e.g. "## Code Review — [title]")
+            2. Findings organized by severity (critical > should-fix > nit)
+            3. If no issues found, explicitly state: "No issues found — code looks good."
+
+            You MUST post exactly one `gh pr comment` with your full review. Do not skip this step.
 
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+
+      - name: Verify review comment was posted
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          post_count=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate --jq 'length')
+          pre_count=${{ steps.pre-count.outputs.count }}
+          echo "Pre-review: ${pre_count} comments, Post-review: ${post_count} comments"
+          if [ "${post_count}" -le "${pre_count}" ]; then
+            echo "::error::Claude Code Review completed but did NOT post a review comment. This means the review silently passed without actually reviewing."
+            exit 1
+          fi
+          echo "Review comment verified — ${post_count} comments (was ${pre_count})"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize]
 
 jobs:
   claude-review:
@@ -24,6 +24,19 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- **Agent Ceremony Automation** — Hooks now automate agent initialization sequence (spawn wrapper, heartbeat setup, status file creation) ([#53](https://github.com/WastelandWares/wasteland-orchestrator/issues/53), [#54](https://github.com/WastelandWares/wasteland-orchestrator/issues/54), [#55](https://github.com/WastelandWares/wasteland-orchestrator/issues/55), [#48](https://github.com/WastelandWares/wasteland-orchestrator/issues/48))
+- **Vocabulary Document** — Comprehensive terminology guide for agent protocol and project conventions ([#36](https://github.com/WastelandWares/wasteland-orchestrator/issues/36))
+- **Architecture Diagrams** — Visual documentation of agent system flow and transaction lifecycle
+
+### Changed
+- **Terminology Update** — Replaced agile terminology across codebase with clearer workflow descriptions ([#52](https://github.com/WastelandWares/wasteland-orchestrator/issues/52))
+- **Python Tool Extraction** — Moved inline Python scripts from shell scripts into dedicated `ww-json-tool.py` for better maintainability and testability ([#62](https://github.com/WastelandWares/wasteland-orchestrator/issues/62))
+
+### Fixed
+- Hook enforcement now properly validates Gitea API usage patterns across all agent types
+
+## [0.1.0] - 2026-02-28
+
+### Added
+- Initial release
+- Agent status tracking system with real-time reporting
+- Transaction system for auditable action groups
+- Gitea API library with dual-auth support (Caddy basic auth + Gitea tokens)
+- PreToolUse and PostToolUse hooks for protocol enforcement
+- Agent protocol specification
+- Dashboard-ready status files and transaction logs
+
+[Unreleased]: https://github.com/WastelandWares/wasteland-orchestrator/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/WastelandWares/wasteland-orchestrator/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ See `skills/agent-protocol/SKILL.md` for the full protocol specification.
 from lib.agent_tx import Transaction
 
 tx = Transaction("dev-lead-ms")
-tx.begin("Implementing assistant skeleton", "Sprint 1 story #17", repo="tquick/meeting-scribe", issue=17)
+tx.begin("Implementing assistant skeleton", "Phase 1 task #17", repo="tquick/meeting-scribe", issue=17)
 tx.action("Created src/assistant.py", "Core assistant class with Ollama client")
 tx.action("Updated pipeline.py", "Integrated assistant as post-transcription stage")
 tx.end("success", "Assistant skeleton in place, ready for model integration")

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Claude Code plugin for multi-agent orchestration: status reporting, transactio
 ## What It Does
 
 - **Agent Status Tracking** — Every agent reports what it's doing in real-time via structured status files
+- **Ceremony Automation** — Hooks automatically orchestrate agent initialization (spawn setup, heartbeat, status registration)
 - **Transaction System** — Groups related actions into auditable units with stated intent and justification
 - **Gitea API Library** — Centralized, dual-auth Gitea access (handles Caddy basic auth + Gitea tokens)
 - **Protocol Enforcement** — PreToolUse hooks verify agents follow conventions (no raw curl, worktree isolation, etc.)
@@ -36,15 +37,23 @@ wasteland-orchestrator/
     posttooluse.py       # PostToolUse: heartbeat, tool tracking
     stop.py              # Stop: cleanup status, archive interrupted transactions
   lib/
-    agent_status.py      # Agent status reporting
-    agent_tx.py          # Transaction system
-    gitea_api.py         # Gitea API client with dual-auth
+    agent_status.sh      # Agent status reporting (shell wrapper)
+    agent_status.py      # Agent status reporting (Python)
+    agent_tx.sh          # Transaction system (shell wrapper)
+    agent_tx.py          # Transaction system (Python)
+    gitea_api.sh         # Gitea API client (shell wrapper)
+    gitea_api.py         # Gitea API client (Python)
+  tools/
+    ww-json-tool.py      # JSON processing utility for agent workflows
   skills/
     agent-protocol/
       SKILL.md           # Mandatory protocol documentation
   commands/
     status.md            # /status slash command
     tx.md                # /tx slash command
+  docs/
+    VOCABULARY.md        # Agent protocol terminology guide
+    ARCHITECTURE.md      # System design and data flow diagrams
 ```
 
 ## Protocol Overview
@@ -57,6 +66,12 @@ All agents must:
 5. Update persona files with learnings after each session
 
 See `skills/agent-protocol/SKILL.md` for the full protocol specification.
+
+## Documentation
+
+- **VOCABULARY.md** — Terminology guide for agent roles, states, and workflow concepts
+- **ARCHITECTURE.md** — Visual system design including agent initialization flow and transaction lifecycle
+- **Ceremony Automation** — Hooks automatically initialize agents with proper status tracking and spawn handling
 
 ## Agent States
 

--- a/commands/cook.md
+++ b/commands/cook.md
@@ -1,0 +1,72 @@
+---
+name: cook
+description: Activate "Let Claude Cook" mode — autonomous work with queued user messages
+---
+
+# /cook — Let Claude Cook 🔥
+
+Activate autonomous work mode. While cooking:
+- Claude works continuously without interruption
+- User messages are queued (via btw system) instead of interrupting workflow
+- Claude acknowledges queued messages briefly and continues working
+- Between major task boundaries, Claude checks and processes the queue
+
+## Activation
+
+When this command is invoked:
+
+$ARGUMENTS
+
+1. Source the cook library and activate:
+   ```bash
+   source ~/.claude/lib/cook.sh
+   cook_activate "$ARGUMENTS"
+   ```
+
+2. Respond with a fun cooking-themed confirmation, e.g.:
+   - "🔥 Kitchen's hot — let me cook!"
+   - "🍳 Chef's in the zone. Messages will be queued."
+   - "👨‍🍳 Apron on. I'll check your messages between courses."
+
+3. **CRITICAL BEHAVIORAL CHANGE — From this point forward:**
+
+   When cook mode is active (`~/.claude/state/cook-mode.json` has `"active": true`):
+
+   a. **On receiving any user message:**
+      - First, check if it contains an exit keyword: `cook_check_exit "<message>"`
+      - If exit keyword detected → run `/uncook` behavior (deactivate, show summary)
+      - Otherwise → queue it: `cook_queue_message "<message>"`
+      - Respond ONLY with a brief single-line acknowledgment like:
+        `📝 Queued: "<brief summary of message>"`
+      - Immediately continue your current task. Do NOT engage with message content.
+
+   b. **Between major task completions:**
+      - Check the btw queue: `source ~/.claude/lib/btw.sh && btw_check`
+      - If items pending, review them and decide:
+        - Urgent/relevant to current work → process inline
+        - Everything else → leave queued for later
+      - Continue to next task
+
+   c. **Exit keywords** that deactivate cook mode:
+      - "stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"
+      - Or the `/uncook` command
+
+   d. **The mode persists across context compactions** because state is stored in the filesystem at `~/.claude/state/cook-mode.json`
+
+## Example Session
+
+```
+User: /cook implementing the auth system
+Claude: 🔥 Kitchen's hot! Working on: implementing the auth system
+        Messages will be queued — say "stop" or /uncook to exit cook mode.
+
+User: oh also make sure to add rate limiting
+Claude: 📝 Queued: "add rate limiting"
+[continues working on auth system]
+
+User: hey
+Claude: 🍳 Cook mode deactivated!
+        1 message was queued:
+        1. "oh also make sure to add rate limiting"
+        Ready for normal conversation.
+```

--- a/commands/status.md
+++ b/commands/status.md
@@ -19,13 +19,13 @@ When the user runs `/status`, do the following:
 ## Agent Status
 | Agent | State | Task | Last Heartbeat | Alive |
 |-------|-------|------|----------------|-------|
-| pm | working | Planning sprint 2 | 30s ago | yes |
+| pm | working | Planning phase 2 | 30s ago | yes |
 | dev-lead-ms | idle | Ready | 2m ago | yes |
 
 ## Active Transactions
 | Agent | Intent | Actions | Started |
 |-------|--------|---------|---------|
-| pm | Planning sprint 2 | 3 actions | 5m ago |
+| pm | Planning phase 2 | 3 actions | 5m ago |
 ```
 
 4. Flag any stale agents (heartbeat > 5 minutes) or dead processes

--- a/commands/tx.md
+++ b/commands/tx.md
@@ -13,7 +13,7 @@ Manage work transactions for audit trail and dashboard visibility.
 Start a new transaction:
 ```bash
 source ~/.claude/lib/agent-tx.sh
-tx_begin "Implementing feature X" "Sprint 1 story #42" "tquick/repo" 42
+tx_begin "Implementing feature X" "Phase 1 task #42" "tquick/repo" 42
 ```
 
 ### `/tx action <what> | <why>`

--- a/commands/uncook.md
+++ b/commands/uncook.md
@@ -1,0 +1,32 @@
+---
+name: uncook
+description: Exit "Let Claude Cook" mode and show queued message summary
+---
+
+# /uncook — Exit Cook Mode
+
+Deactivate cook mode and return to normal interactive behavior.
+
+## Behavior
+
+When this command is invoked:
+
+1. Source the cook library and deactivate:
+   ```bash
+   source ~/.claude/lib/cook.sh
+   cook_deactivate
+   ```
+
+2. Display the summary output from `cook_deactivate`, which shows:
+   - How long the cook session lasted
+   - How many messages were queued
+   - List of all queued messages with timestamps
+
+3. Return to normal interactive behavior — respond to user messages directly instead of queuing them.
+
+4. If there are queued messages, offer to process them:
+   - "Would you like me to go through the queued messages now?"
+   - Or process them directly if the context makes it clear
+
+5. If cook mode was not active, say so:
+   - "Cook mode isn't active. Use `/cook` to start an autonomous work session."

--- a/docs/cook-mode.md
+++ b/docs/cook-mode.md
@@ -1,0 +1,75 @@
+# Cook Mode — "Let Claude Cook" 🔥
+
+## Overview
+
+Cook mode enables autonomous work sessions where Claude works continuously without interruption. User messages are queued via the btw system and processed at task boundaries.
+
+## Commands
+
+- **`/cook [task description]`** — Activate cook mode with an optional task description
+- **`/uncook`** — Deactivate cook mode and show queued message summary
+- **Exit keywords**: "stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"
+
+## Architecture
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `~/.claude/lib/cook.sh` | Shell helpers (activate, deactivate, queue, check exit) |
+| `~/.claude/commands/cook.md` | `/cook` slash command definition |
+| `~/.claude/commands/uncook.md` | `/uncook` slash command definition |
+| `~/.claude/state/cook-mode.json` | Persistent state file |
+
+### State File Schema
+
+```json
+{
+  "active": true,
+  "started_at": "2026-03-11T10:30:00",
+  "task": "Implementing auth system",
+  "messages_queued": 3,
+  "exit_keywords": ["stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"]
+}
+```
+
+### Integration Points
+
+- **Statusline**: Shows `🔥 COOKING` prefix when active
+- **HQ Dashboard**: Displays cook mode badge with task and queue count
+- **btw queue**: Queued messages are tagged with `cook_mode: true`
+- **hq-status-writer.py**: Exposes `cook_mode` field in status.json
+
+## Behavioral Contract
+
+When cook mode is active:
+
+1. **User messages are queued**, not processed inline
+2. **Brief acknowledgment** is given: `📝 Queued: "<summary>"`
+3. **Exit keywords** checked before queuing — if detected, cook mode deactivates
+4. **Task boundaries** are natural checkpoints to review the queue
+5. **State persists** across context compactions (stored on filesystem)
+
+## Shell Library API
+
+```bash
+source ~/.claude/lib/cook.sh
+
+cook_is_active              # Returns 0 if active, 1 if not
+cook_activate "my task"     # Activates cook mode
+cook_deactivate             # Deactivates and shows summary
+cook_queue_message "text"   # Queues a message with cook_mode tag
+cook_check_exit "stop"      # Prints "exit" or "continue"
+```
+
+## Installation
+
+The cook.sh library and command files are installed from wasteland-orchestrator:
+
+```bash
+# From the repo:
+cp lib/cook.sh ~/.claude/lib/cook.sh
+cp commands/cook.md ~/.claude/commands/cook.md
+cp commands/uncook.md ~/.claude/commands/uncook.md
+mkdir -p ~/.claude/state
+```

--- a/docs/plans/2026-03-09-orchestrator-v1.md
+++ b/docs/plans/2026-03-09-orchestrator-v1.md
@@ -1,0 +1,140 @@
+# Wasteland Orchestrator v1.0 — Phase Plan
+
+> **Priority**: This is THE priority. Orchestrator v1 unblocks everything else.
+> **Approved**: 2026-03-09
+> **Issues**: #1, #2, #3, #4, #5, #6
+
+---
+
+## What We Have (v0.1.0)
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Agent status files | **Working** | JSON at ~/.claude/agents/status/*.json |
+| Status Python lib | **Working** | `AgentStatus` class, `list_agents()` |
+| Transaction system | **Working** | `Transaction` class, begin/action/end, log archive |
+| Gitea API client | **Working** | `GiteaClient` with dual-auth, CRUD for issues |
+| PreToolUse hook | **Working** | Heartbeat, Gitea enforcement, worktree warnings |
+| Stop hook | **Working** | Status cleanup, interrupted tx archival |
+| Bash shell libs | **Working** | agent-status.sh, gitea-api.sh, agent-tx.sh |
+| Slash commands | **Working** | /status, /tx |
+
+## What We Need (v1.0)
+
+| Component | Issue | Complexity |
+|-----------|-------|-----------|
+| Phase manifest format | #1 | small |
+| Dispatcher (the brain) | #2 | large |
+| Health monitor | #3 | medium |
+| Conflict detection | #4 | medium |
+| Gitea auto-updates | #5 | small |
+| PM manifest generator | #6 | small |
+
+---
+
+## Implementation Order
+
+### Phase 1: Foundation (do first, enables everything)
+
+**#1 Phase Manifest** → Define the YAML format. Everything reads from this.
+
+**#6 PM Manifest Generator** → So we can auto-produce manifests from Gitea issues.
+
+### Phase 2: Core Dispatcher (the main build)
+
+**#2 Dispatcher** → The main `swarm.py` that:
+- Parses manifest
+- Builds dependency DAG
+- Spawns `claude -p` agents with correct context
+- Tracks PIDs and maps to tasks
+- Waits for completion
+
+### Phase 3: Safety & Polish
+
+**#4 Conflict Detection** → File ownership graph, serialization of overlapping tasks.
+
+**#3 Health Monitor** → Heartbeat checks, stall detection, retry logic.
+
+**#5 Gitea Integration** → Auto-close issues, progress comments.
+
+---
+
+## Architecture
+
+```
+                    ┌─────────────────────┐
+                    │   PM Agent (Elara)  │
+                    │  Designs phase,    │
+                    │  generates manifest │
+                    └─────────┬───────────┘
+                              │
+                              ▼
+                    ┌─────────────────────┐
+                    │    phase.yaml      │
+                    │  (manifest file)    │
+                    └─────────┬───────────┘
+                              │
+                              ▼
+            ┌─────────────────────────────────┐
+            │        swarm.py (dispatcher)     │
+            │                                  │
+            │  ┌──────────┐  ┌──────────────┐ │
+            │  │ DAG /    │  │  Conflict    │ │
+            │  │ Scheduler│  │  Detector    │ │
+            │  └────┬─────┘  └──────────────┘ │
+            │       │                          │
+            │  ┌────┴─────────────────────┐   │
+            │  │     Agent Monitor        │   │
+            │  │  heartbeat / stall /     │   │
+            │  │  retry / Gitea updates   │   │
+            │  └──┬──────┬──────┬─────────┘   │
+            └─────┼──────┼──────┼─────────────┘
+                  │      │      │
+          ┌───────┘      │      └───────┐
+          ▼              ▼              ▼
+    ┌──────────┐  ┌──────────┐  ┌──────────┐
+    │ claude -p│  │ claude -p│  │ claude -p│
+    │ dev-ui   │  │ dev-intg │  │ dev-test │
+    │ task #8 │  │ task #16│  │ task #17│
+    └──────────┘  └──────────┘  └──────────┘
+          │              │              │
+          ▼              ▼              ▼
+    status/*.json  status/*.json  status/*.json
+```
+
+## Key Design Decisions
+
+1. **`claude -p` not interactive sessions**: Print mode exits when done, gives us clean process lifecycle. Budget caps work. Output is capturable.
+
+2. **YAML manifest not database**: Human-editable, version-controllable, reviewable before dispatch. PM can tweak before launching.
+
+3. **File-based monitoring not IPC**: Status JSON files are the communication channel. No sockets, no message queues. Simple, debuggable, already working.
+
+4. **Serialization over conflict resolution**: v1 prevents conflicts by never running overlapping tasks in parallel. Smarter merging can come in v2.
+
+5. **One worktree per phase, not per task**: Keeps git simple. Tasks run sequentially when they share files, so the single worktree stays clean.
+
+---
+
+## Success Criteria
+
+After v1.0, running a phase looks like:
+
+```bash
+# PM generates manifest from Gitea issues
+python3 generate_manifest.py tquick/claude-gate --output phase.yaml
+
+# Human reviews/tweaks manifest
+vim phase.yaml
+
+# Launch the swarm
+python3 swarm.py phase.yaml
+
+# Watch progress (separate terminal)
+python3 swarm.py --status
+
+# Or just watch Gitea — issues auto-close as tasks complete
+```
+
+No manual `claude -p` commands. No copy-pasting prompts. No checking terminals.
+The dispatcher handles spawn, monitor, retry, report, close.

--- a/docs/plans/2026-03-12-ceremony-automation.md
+++ b/docs/plans/2026-03-12-ceremony-automation.md
@@ -1,0 +1,131 @@
+# Agent Ceremony Automation
+
+**Date**: 2026-03-12
+**Issues**: #48, #53, #54, #55
+**Status**: Implemented
+
+## Problem
+
+Agents waste 10-15 turns on startup ceremony:
+- Manually sourcing libraries (`source ~/.claude/lib/agent-status.sh`)
+- Reading pinboard (`~/.claude/bin/pinboard read`)
+- Setting agent name (`export CLAUDE_AGENT_NAME=...`)
+- Starting transactions (`tx_begin ...`)
+- Checking project status
+
+This is overhead that should be automated via Claude Code hooks.
+
+## Solution
+
+### Issue #53 — Pinboard Read in SessionStart Hook
+
+**File**: `~/.claude/hooks/agent-startup.sh`
+
+The SessionStart hook now reads `~/.claude/pinboard.json` and injects active
+pins into the agent's context via `hookSpecificOutput.additionalContext`.
+
+Agents no longer need to run `~/.claude/bin/pinboard read` — pins appear
+automatically in a `<pinboard>` tag in their context.
+
+### Issue #54 — Auto tx_begin on Subagent Spawn
+
+**Files**: `~/.claude/hooks/subagent-start.sh`, `~/.claude/hooks/subagent-stop.sh`
+
+New `SubagentStart` and `SubagentStop` hooks registered in `~/.claude/settings.json`:
+
+- **SubagentStart**: Fires `tx_begin` automatically for real subagents (skips
+  built-in lightweight agents like Bash, Explore, Plan). Injects context about
+  the parent agent and dispatch instructions.
+- **SubagentStop**: Fires `tx_end` automatically, closing the transaction
+  with a success outcome.
+
+Agents no longer need to manually call `tx_begin`/`tx_end`.
+
+### Issue #55 — Pass PM Context to Dev-Leads
+
+**Files**: `~/.claude/state/dispatch-context.json` (runtime), `~/.claude/lib/dispatch.sh`
+
+New dispatch context system:
+
+1. PM (or any dispatcher) calls `dispatch_write_context` before spawning an agent
+2. Writes a JSON file at `~/.claude/state/dispatch-context.json` containing:
+   - Briefing summary
+   - Issue bodies (fetched from Gitea)
+   - Recent commits
+   - Cross-project dependencies
+   - Custom instructions
+3. SessionStart hook reads this file and injects it as `<dispatch-context>`
+4. File is marked as consumed after injection (with TTL check: 5 min)
+
+The `agent-spawn` wrapper also writes this context automatically.
+
+### Issue #48 — Enforce Agent Metadata via Spawn Tooling
+
+**Files**: `~/.claude/bin/agent-spawn`, `~/.claude/hooks/agent-startup.sh`
+
+Two-pronged approach:
+
+1. **`agent-spawn` wrapper**: Sets `CLAUDE_AGENT_NAME`, creates the status file,
+   and writes dispatch context BEFORE the Claude session starts. Usage:
+   ```bash
+   agent-spawn --agent=dev-lead --project=dnd-tools --issue=8
+   ```
+
+2. **SessionStart hook + CLAUDE_ENV_FILE**: The hook detects the agent name from:
+   - `CLAUDE_AGENT_NAME` env var (set by spawn wrapper)
+   - `agent_type` from hook input (set by `--agent` flag)
+   - Dispatch context file
+   - Directory-based inference (fallback)
+
+   It then writes `export CLAUDE_AGENT_NAME="..."` to `$CLAUDE_ENV_FILE`,
+   which Claude Code makes available to all subsequent Bash tool calls.
+
+## Settings Changes
+
+`~/.claude/settings.json` now includes:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [{ "hooks": [{ "type": "command", "command": "agent-startup.sh", "timeout": 15 }] }],
+    "SubagentStart": [{ "hooks": [{ "type": "command", "command": "subagent-start.sh", "timeout": 10 }] }],
+    "SubagentStop": [{ "hooks": [{ "type": "command", "command": "subagent-stop.sh", "timeout": 10 }] }],
+    "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "verify-agent-protocol.sh" }] }],
+    "Stop": [{ "hooks": [{ "type": "command", "command": "agent-shutdown.sh" }] }]
+  }
+}
+```
+
+## Dispatch Context Schema
+
+```json
+{
+  "agent_name": "dev-lead",
+  "repo": "tquick/dnd-tools",
+  "issue_number": "8",
+  "created_at": "2026-03-12T14:00:00+00:00",
+  "created_by": "pm",
+  "consumed": false,
+  "briefing_summary": "...",
+  "issue_bodies": [{ "number": 8, "title": "...", "body": "...", "labels": [] }],
+  "recent_commits": "abc123 feat: ...\ndef456 fix: ...",
+  "cross_dependencies": "...",
+  "phase_plan": "...",
+  "custom_instructions": "..."
+}
+```
+
+## Turn Savings
+
+Before: ~10-15 turns of ceremony per agent session
+After: 0 turns — everything happens in hooks before the agent's first response
+
+| Action | Before | After |
+|--------|--------|-------|
+| Source libraries | 1-2 turns | Hook (auto) |
+| Set agent name | 1 turn | Hook + CLAUDE_ENV_FILE (auto) |
+| Read pinboard | 1-2 turns | Hook → additionalContext (auto) |
+| tx_begin | 1 turn | SubagentStart hook (auto) |
+| Read dispatch context | 2-3 turns | Hook → additionalContext (auto) |
+| Create status file | 1 turn | Hook + spawn wrapper (auto) |
+| **Total** | **~10 turns** | **0 turns** |

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -16,15 +16,19 @@ Autonomous agent work mode. When activated (`/cook`), the agent works without in
 **Statusline indicator:** 🔥 COOKING
 
 ### btw (By The Way)
-Non-interrupting message queue used during Cook Mode. When an agent is cooking, incoming user messages are queued as btw items rather than breaking the agent's focus. Messages are tagged with `cook_mode: true` and presented as a batch when cook mode deactivates.
+Two distinct but related uses:
 
-**Origin:** wasteland-orchestrator, cook.sh
+1. **Claude Code built-in (`/btw`):** A native command in recent Claude Code builds. Lets you ask a quick side question without adding to conversation history. The question and answer appear in a dismissible overlay and are ephemeral. Works while Claude is processing. Has full conversation visibility but no tool access. The inverse of a subagent (sees full context but no tools, vs. subagent which has tools but empty context).
+
+2. **WastelandWares Cook Mode queue:** When an agent is cooking, incoming user messages are queued as btw items rather than breaking the agent's focus. Messages are tagged with `cook_mode: true` and presented as a batch when cook mode deactivates.
+
+**Origin (Cook Mode):** wasteland-orchestrator, cook.sh
 **Storage:** `~/.claude/btw-queue.json`
 
 ### Transaction (tx)
 An auditable unit of agent work with declared intent. Every meaningful task is wrapped in `tx_begin` / `tx_end`, with intermediate `tx_action` entries logging significant changes. Transactions record:
 - **Intent** — what the agent plans to do (human-readable)
-- **Justification** — why the work is being done (e.g., "Sprint 1 story #18")
+- **Justification** — why the work is being done (e.g., "Phase 1 task #18")
 - **Actions** — timestamped log of what changed and why
 - **Outcome** — `success`, `partial`, `failed`, or `cancelled`
 
@@ -33,25 +37,52 @@ Transactions feed the dashboard, provide an audit trail, and will integrate with
 **Origin:** wasteland-orchestrator, agent-tx.sh
 **Storage:** `~/.claude/agents/transactions/`
 
-### Sprint
-A focused batch of work across one or more projects with named stories, clear owners, and time-boxed execution. Sprints are named (e.g., "First Light," "Ambitious March") and tracked via Gitea `in-sprint` labels.
+### Phase
+A focused batch of work across one or more projects with named tasks, clear owners, and time-boxed execution. Phases are named (e.g., "First Light," "Ambitious March") and tracked via Gitea `in-phase` labels.
 
-### Story
-A single deliverable within a sprint, mapped to a Gitea issue. Stories have complexity labels (`trivial`, `small`, `medium`, `large`, `epic`) and tier priority (`now`, `next`, `later`, `icebox`).
+> **Note:** We deliberately avoid the term "sprint" and other Scrum/Agile terminology. Those words carry deep associations with two-week dev cycles, velocity tracking, story pointing, and baked-in wait times — concepts that don't apply to how WastelandWares operates. See *Rule 1/137, the fine-task constant.*
 
-### Epic
-A large initiative spanning multiple stories and potentially multiple sprints. Tracked as a Gitea issue with `complexity:epic` label, often serving as a parent tracker (e.g., jarlf-host#1).
+### Task
+An actionable item of work, mapped to a Gitea issue. Tasks have complexity labels (`trivial`, `small`, `medium`, `large`) and tier priority (`now`, `next`, `later`, `icebox`). If a task is large, it should be decomposed into many smaller tasks.
+
+> **Not "story."** Stories imply narrative structure and estimation rituals. A task is simply: something that needs doing, with enough context to do it.
+
+### Idea
+A workshopable item. Ideas should always be captured with the full context around the ideation — what prompted it, who suggested it, adjacent thoughts — and linked to any duplicate or near-duplicate ideas. Ideas are refined into tasks when they're ready for implementation.
+
+> **Tasks vs. Ideas:** Tasks are actionable. Ideas are explorable. An idea becomes a task when it has a clear definition of done.
+
+### Project (scope)
+A large initiative spanning multiple tasks and potentially multiple phases. Tracked as a Gitea issue with the `project` label, often serving as a parent tracker (e.g., jarlf-host#1).
+
+> **Not "epic."** Epics carry Agile baggage — estimation, velocity, burn-down charts. A project is just: a big thing made of smaller things.
 
 ### Tier
-Priority classification for stories and issues:
+Priority classification for tasks and ideas. A degree of abstraction removed from "priority" — lessens the narrative that tasks and ideas can be ordered deterministically.
 | Tier | Meaning |
 |------|---------|
 | **now** | Active priority — work on this immediately |
-| **next** | Queued — work on this after current sprint |
-| **later** | Planned — will be scheduled in a future sprint |
+| **next** | Queued — work on this after current phase |
+| **later** | Planned — will be scheduled in a future phase |
 | **icebox** | Parked — captured but not currently planned |
 
 Nothing is discarded. Every idea gets at minimum an icebox tier.
+
+### Acceptance Test
+*Needs definition.* Thomas flagged that the vocabulary should cover the acceptance test feature — the process by which a task is verified as complete. To be workshopped.
+
+### Banned Terminology (Rule 1/137 — the fine-task constant)
+Scrum and Agile terminology is banned from WastelandWares vocabulary. These words carry associations that cause actual friction with how we work — assumptions about velocity, story pointing, two-week cadences, and deterministic ordering that don't apply here.
+
+| Banned | Replacement | Why |
+|--------|-------------|-----|
+| Sprint | **Phase** | "Sprint" implies fixed time-boxes, velocity tracking, retrospectives |
+| Story | **Task** | "Story" implies estimation rituals and narrative structure |
+| Epic | **Project** | "Epic" implies burn-down charts and hierarchical decomposition |
+| Backlog grooming | **Triage** | Grooming implies a fixed ceremony |
+| Standup | **Check-in** | We don't stand, and there's no fixed schedule |
+| Velocity | *(no replacement)* | We don't measure throughput in points per sprint |
+| Story points | *(no replacement)* | Complexity labels (trivial→large) are sufficient |
 
 ### Branching Model
 ```
@@ -76,6 +107,8 @@ Commit message prefixes used across all repositories:
 | `refactor:` | Code restructuring |
 | `test:` | Test additions/changes |
 | `chore:` | Maintenance tasks |
+| `fun:` | Fun/experimental/creative work — why do any of this if we can't have fun? |
+| `havoc:` | Security adversary finding — Havoc (our red panda) found a vulnerability. Treated as critical. |
 
 ---
 
@@ -164,7 +197,7 @@ Mandatory startup and operational conventions for all agents. Includes: source s
 Agent identity and memory document at `~/.claude/agents/CLAUDE.{name}.md`. Contains the agent's role definition, character bio, working style, performance log, learnings, and project-specific knowledge. Updated by the agent at end of each session — this is how institutional knowledge accumulates across sessions.
 
 ### WOW (WastelandWares Orchestration Workflow)
-The end-to-end pipeline for how work flows through the agent system: intake → triage → sprint planning → dispatch → implementation → review → merge → docs → release. Named to capture the full orchestration lifecycle.
+The end-to-end pipeline for how work flows through the agent system: intake → triage → phase planning → dispatch → implementation → review → merge → docs → release. Named to capture the full orchestration lifecycle.
 
 ### HitL (Human in the Loop)
 Thomas's role in the agent system. Agents operate autonomously but specific actions require human involvement:
@@ -187,13 +220,13 @@ Thomas / contributors
 
 | Name | Role | Scope |
 |------|------|-------|
-| **Elara** | Project Manager | Cross-project intake, triage, sprint planning, backlog management |
+| **Elara** | Project Manager | Cross-project intake, triage, phase planning, backlog management |
 | **Vex** | Security Reviewer | Security audits, threat modeling, credential hygiene |
 | **Glitch** | Mobile Tester | Mobile app testing, device compatibility, edge cases |
-| **Havoc** | White Hat | Penetration testing, vulnerability research, red team exercises |
+| **Havoc** | Red Panda Adversary | Security vulnerability discovery — `havoc:` commits with proof (tests, scripts, docs). Findings published after set time (zero-day style disclosure). Treated as critical issues. |
 | **Pixel** | Mobile UX | Mobile UI/UX design, accessibility, interaction patterns |
 | **Sigil** | Brand Designer | Visual identity, style guides, marketing assets |
-| **Dev Team Lead** | Sprint Coordinator | Per-project implementation, agent dispatch, review cycle |
+| **Dev Team Lead** | Phase Coordinator | Per-project implementation, agent dispatch, review cycle |
 | **Documentation Agent** | Docs Keeper | Changelog, README, CLAUDE.md reconciliation, end-of-sprint docs |
 
 ---
@@ -290,7 +323,17 @@ A Tier 1 extension that tracks the cumulative predicted effects of approved comm
 The umbrella brand for all projects in the ecosystem. Evokes post-apocalyptic resourcefulness — building useful things from whatever is available.
 
 **Domain:** wastelandwares.com
-**Services:** git.wastelandwares.com (Gitea), dungeoncrawler.wastelandwares.com (game), turtles.wastelandwares.com (dev preview)
+
+**Live services:**
+- `git.wastelandwares.com` — Gitea (issue tracking, mirrors)
+- `dungeoncrawler.wastelandwares.com` — Dungeon crawler game
+- `dev.dungeoncrawler.wastelandwares.com` — Dev preview builds
+- `papers.wastelandwares.com` — Whitepapers (OaP, etc.)
+- `turtles.wastelandwares.com` — Dev preview (legacy)
+
+**Coming soon:**
+- `hq.wastelandwares.com` — HQ dashboard
+- `thomas.wastelandwares.com` — Personal/portfolio
 
 ### Projects
 

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -1,0 +1,342 @@
+# WastelandWares Vocabulary
+
+> **Canonical glossary for the WastelandWares ecosystem.**
+> Living document — add terms as the ecosystem evolves.
+> Last updated: 2026-03-12
+
+---
+
+## Workflow & Process
+
+### Cook Mode
+Autonomous agent work mode. When activated (`/cook`), the agent works without interruption. User messages are queued in the **btw** system rather than processed inline. Exit keywords ("stop", "pause", "hey", "hold on", "wait", "halt") or `/uncook` deactivate cook mode and present the queued messages.
+
+**Origin:** wasteland-orchestrator, cook.sh skill + lib
+**State file:** `~/.claude/state/cook-mode.json`
+**Statusline indicator:** 🔥 COOKING
+
+### btw (By The Way)
+Non-interrupting message queue used during Cook Mode. When an agent is cooking, incoming user messages are queued as btw items rather than breaking the agent's focus. Messages are tagged with `cook_mode: true` and presented as a batch when cook mode deactivates.
+
+**Origin:** wasteland-orchestrator, cook.sh
+**Storage:** `~/.claude/btw-queue.json`
+
+### Transaction (tx)
+An auditable unit of agent work with declared intent. Every meaningful task is wrapped in `tx_begin` / `tx_end`, with intermediate `tx_action` entries logging significant changes. Transactions record:
+- **Intent** — what the agent plans to do (human-readable)
+- **Justification** — why the work is being done (e.g., "Sprint 1 story #18")
+- **Actions** — timestamped log of what changed and why
+- **Outcome** — `success`, `partial`, `failed`, or `cancelled`
+
+Transactions feed the dashboard, provide an audit trail, and will integrate with claude-gate for policy-aware gating. They are the **Audit** component of the Gate → Audit → Undo triad.
+
+**Origin:** wasteland-orchestrator, agent-tx.sh
+**Storage:** `~/.claude/agents/transactions/`
+
+### Sprint
+A focused batch of work across one or more projects with named stories, clear owners, and time-boxed execution. Sprints are named (e.g., "First Light," "Ambitious March") and tracked via Gitea `in-sprint` labels.
+
+### Story
+A single deliverable within a sprint, mapped to a Gitea issue. Stories have complexity labels (`trivial`, `small`, `medium`, `large`, `epic`) and tier priority (`now`, `next`, `later`, `icebox`).
+
+### Epic
+A large initiative spanning multiple stories and potentially multiple sprints. Tracked as a Gitea issue with `complexity:epic` label, often serving as a parent tracker (e.g., jarlf-host#1).
+
+### Tier
+Priority classification for stories and issues:
+| Tier | Meaning |
+|------|---------|
+| **now** | Active priority — work on this immediately |
+| **next** | Queued — work on this after current sprint |
+| **later** | Planned — will be scheduled in a future sprint |
+| **icebox** | Parked — captured but not currently planned |
+
+Nothing is discarded. Every idea gets at minimum an icebox tier.
+
+### Branching Model
+```
+main          ← production, ONLY Thomas merges here
+  └── _dev    ← integration branch, dev-lead may merge feature PRs here
+       ├── feat/issue-8-venmo    ← feature branches target _dev
+       ├── fix/issue-2-healing
+       └── docs/issue-36-vocab
+```
+- Feature branches branch from `_dev` and PR back to `_dev`
+- Dev-lead may merge feature PRs into `_dev` after review passes
+- Releases (`_dev` → `main`) require Thomas's approval and merge
+
+### Conventional Commits
+Commit message prefixes used across all repositories:
+| Prefix | Purpose |
+|--------|---------|
+| `feat:` | New feature |
+| `fix:` | Bug fix |
+| `docs:` | Documentation only |
+| `infra:` | Infrastructure/tooling |
+| `refactor:` | Code restructuring |
+| `test:` | Test additions/changes |
+| `chore:` | Maintenance tasks |
+
+---
+
+## Tooling & Infrastructure
+
+### Pinboard
+Shared sticky-note system for human ↔ agent communication. Persistent notes with threading, priority, and resolution tracking. Agents read the pinboard at session start for context; they pin blockers, action items, and discoveries during work.
+
+**Key operations:**
+- `add` — create a note with optional tags, project, priority, and `--needs-human` flag
+- `reply` — add a threaded comment to an existing pin
+- `thread` — view a pin with its full comment history
+- `close` — mark a pin done with an optional resolution note
+- `toggle` — flip done/undone status
+- `read` — compact view for agent context loading
+
+**Flags:** `--needs-human` surfaces the pin prominently (🚨) for Thomas. `--session` attaches a session ID for potential resume. `--priority=low|med|high` sets urgency.
+
+**Origin:** wasteland-orchestrator, `~/.claude/bin/pinboard`
+**Storage:** `~/.claude/pinboard.json`
+
+### Agent Status
+Real-time status reporting system. Every agent writes its current state to a JSON file, visible on the dashboard. States:
+
+| State | Meaning | Future HQ Visual |
+|-------|---------|-------------------|
+| `idle` | No active task | Agent in lounge |
+| `working` | Actively on a task | Agent at desk, typing |
+| `reviewing` | Reviewing code/PR | Agent at review station |
+| `brainstorming` | Design/brainstorm session | Agent at whiteboard |
+| `meeting` | Meeting scribe is live | Agent in meeting room |
+| `blocked` | Waiting on dependency/human | Agent pacing |
+| `starting` | Session initializing | Agent walking in |
+| `stopping` | Session ending | Agent walking out |
+
+**Origin:** wasteland-orchestrator, agent-status.sh
+**Storage:** `~/.claude/agents/status/{agent-name}.json`
+
+### Heartbeat
+Periodic timestamp update in an agent's status file, used to detect stale (crashed/abandoned) sessions. A status with no heartbeat in 5 minutes is flagged as stale.
+
+### Worktree Isolation
+Mandatory practice: all agent dev work happens in git worktrees, never in the main working directory. Each task gets its own worktree branched from `_dev`, ensuring agents never interfere with each other's work or with the main checkout.
+
+```bash
+git worktree add .worktrees/issue-17-skeleton -b feat/issue-17-skeleton origin/_dev
+```
+
+**Origin:** wasteland-orchestrator, agent protocol
+**Enforced by:** PreToolUse hooks warn agents working in the main tree
+
+### Dispatch
+System for launching sub-agents as independent processes. Uses a file-based message queue to avoid nested Claude instance depth limits. A dispatching agent writes a task JSON to `queue/`, a daemon picks it up, spawns a fresh Claude CLI instance, and writes the result to `results/`.
+
+**Task lifecycle:** queued → active → done
+**Max dispatch depth:** 3 (prevents runaway recursion)
+**Priority levels:** normal, high, critical
+
+**Origin:** wasteland-orchestrator, dispatch.sh
+**Storage:** `~/.claude/dispatch/{queue,active,done,results}/`
+
+### Gitea API Helpers
+Shared shell library (`gitea-api.sh`) wrapping all Gitea REST API calls. Agents must never use raw `curl` to Gitea — the library handles dual-auth (Caddy basic auth + Gitea API token), temp-file JSON bodies, and centralized URL/token management.
+
+**Functions:** `gitea_get`, `gitea_post`, `gitea_patch`, `gitea_put`, `gitea_delete`, `gitea_create_issue`
+
+**Origin:** wasteland-orchestrator, gitea-api.sh
+
+### Briefing
+Auto-generated session context provided to agents at startup. Includes recent activity, active pins, and relevant project state. Delivered by the spawn script before the agent's Claude session begins.
+
+### claude-review
+GitHub Actions workflow that runs automated code review on PRs. Deployed across all active repositories. Agents create PRs, wait for claude-review to complete, address any comments, and iterate until review passes.
+
+---
+
+## Agent System
+
+### Agent Protocol
+Mandatory startup and operational conventions for all agents. Includes: source status/gitea/tx libraries → set agent name → report idle → read pinboard → wrap work in transactions → update persona file with learnings → clear status on exit.
+
+**Origin:** wasteland-orchestrator, `skills/agent-protocol/agent-protocol.md`
+**Enforced by:** Hooks verify compliance
+
+### Persona File
+Agent identity and memory document at `~/.claude/agents/CLAUDE.{name}.md`. Contains the agent's role definition, character bio, working style, performance log, learnings, and project-specific knowledge. Updated by the agent at end of each session — this is how institutional knowledge accumulates across sessions.
+
+### WOW (WastelandWares Orchestration Workflow)
+The end-to-end pipeline for how work flows through the agent system: intake → triage → sprint planning → dispatch → implementation → review → merge → docs → release. Named to capture the full orchestration lifecycle.
+
+### HitL (Human in the Loop)
+Thomas's role in the agent system. Agents operate autonomously but specific actions require human involvement:
+- Release merges (`_dev` → `main`)
+- Decisions flagged with `--needs-human` on pinboard
+- Architectural choices and product direction
+- Security-sensitive operations gated by claude-gate
+
+### Chain of Command
+```
+Thomas / contributors
+    → Project Manager (Elara)
+        → Dev Team Lead (per project)
+            → Dev Agents, Test Agent, UI/UX Agent
+        → Documentation Agent
+        → claude-review (automated)
+```
+
+### Agent Personas
+
+| Name | Role | Scope |
+|------|------|-------|
+| **Elara** | Project Manager | Cross-project intake, triage, sprint planning, backlog management |
+| **Vex** | Security Reviewer | Security audits, threat modeling, credential hygiene |
+| **Glitch** | Mobile Tester | Mobile app testing, device compatibility, edge cases |
+| **Havoc** | White Hat | Penetration testing, vulnerability research, red team exercises |
+| **Pixel** | Mobile UX | Mobile UI/UX design, accessibility, interaction patterns |
+| **Sigil** | Brand Designer | Visual identity, style guides, marketing assets |
+| **Dev Team Lead** | Sprint Coordinator | Per-project implementation, agent dispatch, review cycle |
+| **Documentation Agent** | Docs Keeper | Changelog, README, CLAUDE.md reconciliation, end-of-sprint docs |
+
+---
+
+## Security & Policy (Opacity as Policy)
+
+> Concepts from Thomas Quick's white paper: *"Opacity as Policy: Static Undecidability as a Security Primitive for Agentic Shell Execution"* (March 2026, draft). Related projects: **claude-gate**, **zsh-redact-history**.
+
+### OaP (Opacity as Policy)
+The principle that a command's resistance to static analysis is itself a first-class policy signal for denial. If a command resists decomposition into verified primitive operations, that resistance is sufficient grounds for automatic denial — without user escalation, and without further analysis. The burden of legibility falls on the command generator (the agent), not the command validator.
+
+**Key insight:** OaP inverts the conventional relationship between analyzer capability and security coverage. Rather than building ever-more-sophisticated analyzers, OaP treats unanalyzability as the answer, not the problem.
+
+**Origin:** Thomas Quick, opacity_as_policy_v2.docx (March 2026)
+
+### Opacity
+The degree to which a command's runtime effects cannot be determined by static analysis of its syntax. Formally: given a command string *c* and a static analyzer *A*, the opacity of *c* under *A* is the complement of *A*'s coverage — the set of possible runtime effects not captured in *A(c)*.
+
+Opacity is deliberately **analyzer-relative**. A more sophisticated analyzer classifies fewer commands as opaque. OaP does not require a maximally powerful analyzer; it requires a **reference analyzer** whose coverage boundary defines the policy.
+
+### TRANSPARENT / TRANSLUCENT / OPAQUE
+Three-level command classification hierarchy under OaP:
+
+| Classification | Definition | Policy Response |
+|---------------|------------|-----------------|
+| **TRANSPARENT** | All operations statically determinable. Every AST node resolves to a known primitive with known arguments. | Auto-approve against allowlist |
+| **TRANSLUCENT** | Most operations determinable; residual opacity is bounded and low-risk (e.g., variable expansion within a known-safe template). | Auto-approve with logging |
+| **OPAQUE** | Significant operations undeterminable. Includes `eval`, dynamic binary names, encoded payloads, nested command substitution. | **Automatic denial. No user prompt.** |
+
+**Examples:**
+```bash
+# TRANSPARENT — fully decomposable
+echo "hello" > output.txt
+
+# TRANSLUCENT — bounded residual opacity
+grep -r "TODO" $PROJECT_DIR
+
+# OPAQUE — undeterminable, denied without escalation
+eval $(echo -n 'cm0gLXJmIC8=' | base64 -d)
+```
+
+### Terminal Denial
+OaP's policy that OPAQUE commands are denied without escalation to the human. This is distinct from conventional default-deny, which would ask the human to decide. Terminal denial eliminates the rubber-stamping failure mode — a human presented with `eval $(base64 -d ...)` will either rubber-stamp it (defeating security), manually decode it (doesn't scale), or deny it (what OaP does automatically).
+
+### Asymmetric Trust Tiers
+Agents and humans receive different levels of analysis and trust:
+- **Agents** → Tier 1 only (static analysis). Must produce legible commands. OPAQUE = denied.
+- **Humans** → Tier 1 + Tier 2 (static analysis + simulated execution). May use complex constructs with pre-execution visibility.
+
+This reflects differing trust models: agents are high-speed, low-trust, and capable of reformulation. Humans are low-speed, high-trust, and may have legitimate reasons for complex shell constructs.
+
+### Expressive Equivalence
+The claim that for the practical set of operations agents perform, every opaque formulation has a transparent equivalent. An agent that needs to create a file can emit `echo content > file.txt` rather than constructing the command through variable concatenation. This is analogous to how a C compiler doesn't need inline assembly for the vast majority of programs.
+
+**Implication:** When an agent reaches for opaque constructs, that signals something unusual — and in a security context, "unusual" warrants denial, not curiosity.
+
+### Reference Analyzer
+The static analyzer whose coverage boundary defines the OaP policy. Commands inside the boundary are legible; commands outside are not. The policy attaches to the boundary, not to any particular analyzer's implementation. Practical implementations use AST-based parsing (e.g., via `shfmt` or `tree-sitter-bash`).
+
+### Security Plane
+Not a boundary or perimeter (those imply you can draw a line between "inside" and "outside"). A **plane** — a continuous surface where every point is a potential attack/defense interaction. Captures the topology of the problem: there is no "inside" and "outside," only regions of relative opacity and transparency.
+
+The security plane concept explicitly rejects **complacency language** — terms like "air-gapped," "firewalled," and "sandboxed" that create false confidence by implying binary safe/unsafe states. Opacity is a *spectrum*, not a boolean.
+
+**Origin:** Thomas Quick, Gitea issue comment (wasteland-orchestrator #36)
+
+### Complacency Language
+Terms like "air-gapped," "firewalled," "sandboxed" that imply binary security states (safe/unsafe) when the reality is a gradient. OaP explicitly rejects this framing — the policy response is calibrated to the *degree* of opacity rather than a claimed security state. Language that makes you feel safe is often language that makes you unsafe.
+
+### Gate → Audit → Undo Triad
+The complete lifecycle that three WastelandWares systems form together, each operating on the security plane at a different phase:
+
+| Phase | System | Function |
+|-------|--------|----------|
+| **Pre-execution** | OaP / claude-gate | Gates commands by opacity classification |
+| **During execution** | Transactions (tx) | Audits intent, actions, and outcomes |
+| **Post-execution** | Rollback layers | Enables reversal of changes |
+
+This is the unifying philosophy behind the WastelandWares security tooling. Each component addresses a different temporal phase of the same security surface.
+
+### Two-Tier Verification Architecture
+OaP's proposed verification system:
+- **Tier 1 (Static Decomposition):** Command is parsed into an AST, walked to produce an intermediate representation of primitive operations (EXEC, READ, WRITE, PIPE, REDIRECT, etc.), and classified against an allowlist. Available to agents and humans.
+- **Tier 2 (Simulated Execution):** Command is run against a consequence-free environment (in-memory virtual filesystem, null network layer, simulated process table). Available to humans only.
+
+### Session-Level Effect Accumulator
+A Tier 1 extension that tracks the cumulative predicted effects of approved commands across a session. Detects multi-step attack patterns where individually transparent commands compose into harmful sequences (e.g., `curl URL > payload && chmod +x payload && ./payload`).
+
+---
+
+## Business & Product
+
+### WastelandWares
+The umbrella brand for all projects in the ecosystem. Evokes post-apocalyptic resourcefulness — building useful things from whatever is available.
+
+**Domain:** wastelandwares.com
+**Services:** git.wastelandwares.com (Gitea), dungeoncrawler.wastelandwares.com (game), turtles.wastelandwares.com (dev preview)
+
+### Projects
+
+| Project | Description |
+|---------|-------------|
+| **wasteland-orchestrator** | Claude Code plugin for multi-agent orchestration — hooks, libs, skills, commands |
+| **claude-gate** | Biometric permission gating for Claude Code — macOS native app with rule engine |
+| **meeting-scribe** | Live meeting transcription with AI assistant — Python server + Obsidian plugin |
+| **wasteland-infra** | Infrastructure-as-code for all wastelandwares.com services |
+| **wasteland-hq** | Game-like dev operations dashboard — watch AI agents work in real-time |
+| **dnd-tools** | D&D dungeon crawler web game |
+| **neuroscript-rs** | Neural architecture composition language in Rust |
+| **JARLF** | Just a Really Long Finger — Android biometric auth bridged to macOS (commercial) |
+
+### JARLF (Just a Really Long Finger)
+Commercial product: Android biometric authentication bridged to macOS + remote script execution. DroidID replacement. Multi-repo architecture (jarlf-host, jarlf-mobile, jarlf-core, jarlf-server, jarlf-docs).
+
+**Business model:** $25, 10-day free trial, license keys outside app stores, 3rd party payment processor.
+
+---
+
+## Acronyms
+
+| Acronym | Expansion | Context |
+|---------|-----------|---------|
+| **WOW** | WastelandWares Orchestration Workflow | The end-to-end agent pipeline |
+| **HitL** | Human in the Loop | Thomas's supervisory role |
+| **OaP** | Opacity as Policy | Security principle from Thomas's white paper |
+| **tx** | Transaction | Auditable work unit with intent |
+| **btw** | By The Way | Non-interrupting message queue for cook mode |
+| **PR** | Pull Request | Code review unit on GitHub |
+| **AST** | Abstract Syntax Tree | Used in OaP command parsing |
+| **IR** | Intermediate Representation | Tier 1 primitive operations decomposition |
+| **IaC** | Infrastructure as Code | wasteland-infra approach |
+| **MCP** | Model Context Protocol | Tool integration standard |
+| **JARLF** | Just a Really Long Finger | Android→macOS biometric bridge product |
+| **PM** | Project Manager | Elara's role |
+| **SDK** | Software Development Kit | Claude Agent SDK |
+| **CI/CD** | Continuous Integration / Continuous Deployment | GitHub Actions + Gitea runners |
+
+---
+
+## Contributing to This Document
+
+When introducing new terminology:
+1. Add it to the appropriate domain section
+2. Include a clear definition, origin note, and any relevant storage paths or CLI references
+3. Add acronyms to the acronyms table
+4. Keep definitions precise but accessible — assume the reader is a new contributor or agent being onboarded

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -227,7 +227,7 @@ Thomas / contributors
 | **Pixel** | Mobile UX | Mobile UI/UX design, accessibility, interaction patterns |
 | **Sigil** | Brand Designer | Visual identity, style guides, marketing assets |
 | **Dev Team Lead** | Phase Coordinator | Per-project implementation, agent dispatch, review cycle |
-| **Documentation Agent** | Docs Keeper | Changelog, README, CLAUDE.md reconciliation, end-of-sprint docs |
+| **Documentation Agent** | Docs Keeper | Changelog, README, CLAUDE.md reconciliation, end-of-phase docs |
 
 ---
 

--- a/generate_manifest.py
+++ b/generate_manifest.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Generate a sprint manifest YAML from Gitea in-sprint issues.
+"""Generate a phase manifest YAML from Gitea issues.
 
 Queries Gitea for open issues with the 'in-sprint' label (or a specified
-milestone) and produces a sprint.yaml suitable for the dispatcher.
+milestone) and produces a phase.yaml suitable for the dispatcher.
 
 Usage:
-    python3 generate_manifest.py tquick/claude-gate --output sprint.yaml
+    python3 generate_manifest.py tquick/claude-gate --output phase.yaml
     python3 generate_manifest.py tquick/claude-gate --milestone 3
     python3 generate_manifest.py tquick/claude-gate --label in-sprint
 """
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 from lib.gitea_api import GiteaClient
-from lib.manifest import SprintManifest, Story
+from lib.manifest import PhaseManifest, Task
 
 
 def extract_files(body: str) -> list[str]:
@@ -42,7 +42,7 @@ def extract_files(body: str) -> list[str]:
 
 
 def extract_depends_on(body: str) -> list[str]:
-    """Extract dependency story IDs from issue body.
+    """Extract dependency task IDs from issue body.
 
     Looks for 'depends on: #X, #Y' or a '## Dependencies' section.
     """
@@ -73,18 +73,18 @@ def extract_agent(issue: dict) -> str:
 def issues_to_manifest(
     repo: str,
     issues: list[dict],
-    sprint_name: str = "",
+    phase_name: str = "",
     max_parallel: int = 3,
-) -> SprintManifest:
-    """Convert Gitea issues to a SprintManifest."""
-    stories = []
+) -> PhaseManifest:
+    """Convert Gitea issues to a PhaseManifest."""
+    tasks = []
     for issue in issues:
-        story_id = f"#{issue['number']}"
+        task_id = f"#{issue['number']}"
         body = issue.get("body", "") or ""
 
-        stories.append(
-            Story(
-                id=story_id,
+        tasks.append(
+            Task(
+                id=task_id,
                 title=issue["title"],
                 agent=extract_agent(issue),
                 repo=repo,
@@ -98,26 +98,26 @@ def issues_to_manifest(
         )
 
     # Sort by issue number for deterministic ordering
-    stories.sort(key=lambda s: s.issue or 0)
+    tasks.sort(key=lambda s: s.issue or 0)
 
-    return SprintManifest(
-        sprint=sprint_name or f"{repo.split('/')[-1]}-sprint",
+    return PhaseManifest(
+        phase=phase_name or f"{repo.split('/')[-1]}-phase",
         project=repo.split("/")[-1],
         repo=repo,
-        stories=stories,
+        tasks=tasks,
         max_parallel=max_parallel,
     )
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate sprint manifest from Gitea issues"
+        description="Generate phase manifest from Gitea issues"
     )
     parser.add_argument("repo", help="Repository in owner/name format")
-    parser.add_argument("--output", "-o", default="sprint.yaml", help="Output file")
+    parser.add_argument("--output", "-o", default="phase.yaml", help="Output file")
     parser.add_argument("--label", "-l", default="in-sprint", help="Label to filter by")
     parser.add_argument("--milestone", "-m", type=int, help="Milestone ID to filter by")
-    parser.add_argument("--sprint", "-s", help="Sprint name override")
+    parser.add_argument("--phase", "-s", help="Phase name override")
     parser.add_argument("--max-parallel", type=int, default=3, help="Max parallel agents")
 
     args = parser.parse_args()
@@ -147,13 +147,13 @@ def main():
 
     manifest = issues_to_manifest(
         args.repo, issues,
-        sprint_name=args.sprint,
+        phase_name=args.phase,
         max_parallel=args.max_parallel,
     )
 
     output = Path(args.output)
     manifest.to_yaml(output)
-    print(f"Generated {output} with {len(manifest.stories)} stories")
+    print(f"Generated {output} with {len(manifest.tasks)} tasks")
 
 
 if __name__ == "__main__":

--- a/hooks/global/agent-spawn
+++ b/hooks/global/agent-spawn
@@ -83,33 +83,36 @@ fi
 DISPATCH_CTX_FILE="${HOME}/.claude/state/dispatch-context.json"
 mkdir -p "${HOME}/.claude/state"
 
-python3 -c "
+# Export vars for Python script to use
+export AGENT_NAME PROJECT ISSUE CONTEXT BRIEFING REPO_OWNER DISPATCH_CTX_FILE
+
+python3 << 'PYTHON_EOF'
 import json, subprocess, os, datetime
 
 ctx = {
-    'agent_name': '${AGENT_NAME}',
-    'project': '${PROJECT}',
-    'repo': '${REPO_OWNER}/${PROJECT}' if '${PROJECT}' else '',
-    'issue_number': '${ISSUE}' if '${ISSUE}' else None,
+    'agent_name': os.environ.get('AGENT_NAME', ''),
+    'project': os.environ.get('PROJECT', ''),
+    'repo': f"{os.environ.get('REPO_OWNER', 'tquick')}/{os.environ.get('PROJECT', '')}" if os.environ.get('PROJECT') else '',
+    'issue_number': os.environ.get('ISSUE') if os.environ.get('ISSUE') else None,
     'created_at': datetime.datetime.now(datetime.timezone.utc).isoformat(),
     'created_by': os.environ.get('CLAUDE_AGENT_NAME', 'thomas'),
     'consumed': False,
 }
 
 # Include briefing if provided
-briefing_path = '${BRIEFING}'
+briefing_path = os.environ.get('BRIEFING', '')
 if briefing_path and os.path.isfile(briefing_path):
     with open(briefing_path) as f:
         ctx['briefing_summary'] = f.read()[:5000]
 
 # Include custom instructions
-custom = '''${CONTEXT}'''
+custom = os.environ.get('CONTEXT', '')
 if custom:
     ctx['custom_instructions'] = custom
 
 # Include recent commits for the project
-if '${PROJECT}':
-    project_dir = os.path.expanduser(f'~/projects/${PROJECT}')
+if os.environ.get('PROJECT'):
+    project_dir = os.path.expanduser(f"~/projects/{os.environ.get('PROJECT')}")
     if os.path.isdir(project_dir):
         try:
             result = subprocess.run(
@@ -122,9 +125,10 @@ if '${PROJECT}':
         except:
             pass
 
-with open('${DISPATCH_CTX_FILE}', 'w') as f:
+with open(os.environ.get('DISPATCH_CTX_FILE', ''), 'w') as f:
     json.dump(ctx, f, indent=2)
-" 2>/dev/null || true
+PYTHON_EOF
+ 2>/dev/null || true
 
 # ── Resolve project directory ──
 LAUNCH_DIR="${HOME}/projects"

--- a/hooks/global/agent-spawn
+++ b/hooks/global/agent-spawn
@@ -1,0 +1,140 @@
+#!/bin/bash
+# agent-spawn — Wrapper to launch Claude agent sessions with metadata pre-set
+#
+# Issue #48: Enforce agent metadata via spawn tooling
+#
+# This script:
+# 1. Sets CLAUDE_AGENT_NAME before the session starts
+# 2. Creates the status file immediately (not after agent's first turn)
+# 3. Writes dispatch context for the agent to consume (#55)
+# 4. Launches claude with proper --agent flag
+#
+# Usage:
+#   agent-spawn --agent=dev-lead --project=dnd-tools [--issue=8] [--context="briefing text"]
+#   agent-spawn --agent=codsworth --project=meeting-scribe --issue=24
+#   agent-spawn --agent=pm  # No project needed for PM
+#
+# All flags after -- are passed directly to claude CLI.
+
+set -euo pipefail
+
+# ── Parse arguments ──
+AGENT_NAME=""
+PROJECT=""
+ISSUE=""
+CONTEXT=""
+BRIEFING=""
+REPO_OWNER="tquick"
+EXTRA_CLAUDE_ARGS=()
+PASS_THROUGH=false
+
+for arg in "$@"; do
+  if [[ "$PASS_THROUGH" == "true" ]]; then
+    EXTRA_CLAUDE_ARGS+=("$arg")
+    continue
+  fi
+  case "$arg" in
+    --agent=*)    AGENT_NAME="${arg#--agent=}" ;;
+    --project=*)  PROJECT="${arg#--project=}" ;;
+    --issue=*)    ISSUE="${arg#--issue=}" ;;
+    --context=*)  CONTEXT="${arg#--context=}" ;;
+    --briefing=*) BRIEFING="${arg#--briefing=}" ;;
+    --)           PASS_THROUGH=true ;;
+    --help|-h)
+      echo "Usage: agent-spawn --agent=NAME --project=PROJECT [--issue=N] [--context=TEXT] [--briefing=FILE]"
+      echo ""
+      echo "Options:"
+      echo "  --agent=NAME      Agent persona name (required)"
+      echo "  --project=PROJECT Project directory name under ~/projects/"
+      echo "  --issue=N         Focus issue number"
+      echo "  --context=TEXT    Custom context/instructions to inject"
+      echo "  --briefing=FILE   Path to briefing file to include"
+      echo "  --                Everything after this is passed to claude CLI"
+      exit 0 ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      echo "Run 'agent-spawn --help' for usage." >&2
+      exit 1 ;;
+  esac
+done
+
+if [[ -z "$AGENT_NAME" ]]; then
+  echo "Error: --agent=NAME is required" >&2
+  exit 1
+fi
+
+# ── Set up environment BEFORE launching claude ──
+
+# 1. Export agent name so the SessionStart hook picks it up
+export CLAUDE_AGENT_NAME="$AGENT_NAME"
+
+# 2. Source libraries for status/tx
+source "${HOME}/.claude/lib/init.sh" 2>/dev/null || true
+
+# 3. Create status file immediately (#48)
+if type agent_status_update &>/dev/null; then
+  REPO_REF=""
+  [[ -n "$PROJECT" ]] && REPO_REF="${REPO_OWNER}/${PROJECT}"
+  ISSUE_REF="${ISSUE:-}"
+  agent_status_update "starting" "Spawning: ${AGENT_NAME}" "$REPO_REF" "$ISSUE_REF" 2>/dev/null || true
+fi
+
+# 4. Write dispatch context (#55)
+DISPATCH_CTX_FILE="${HOME}/.claude/state/dispatch-context.json"
+mkdir -p "${HOME}/.claude/state"
+
+python3 -c "
+import json, subprocess, os, datetime
+
+ctx = {
+    'agent_name': '${AGENT_NAME}',
+    'project': '${PROJECT}',
+    'repo': '${REPO_OWNER}/${PROJECT}' if '${PROJECT}' else '',
+    'issue_number': '${ISSUE}' if '${ISSUE}' else None,
+    'created_at': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    'created_by': os.environ.get('CLAUDE_AGENT_NAME', 'thomas'),
+    'consumed': False,
+}
+
+# Include briefing if provided
+briefing_path = '${BRIEFING}'
+if briefing_path and os.path.isfile(briefing_path):
+    with open(briefing_path) as f:
+        ctx['briefing_summary'] = f.read()[:5000]
+
+# Include custom instructions
+custom = '''${CONTEXT}'''
+if custom:
+    ctx['custom_instructions'] = custom
+
+# Include recent commits for the project
+if '${PROJECT}':
+    project_dir = os.path.expanduser(f'~/projects/${PROJECT}')
+    if os.path.isdir(project_dir):
+        try:
+            result = subprocess.run(
+                ['git', 'log', '--oneline', '-15'],
+                capture_output=True, text=True, timeout=5,
+                cwd=project_dir
+            )
+            if result.returncode == 0:
+                ctx['recent_commits'] = result.stdout.strip()
+        except:
+            pass
+
+with open('${DISPATCH_CTX_FILE}', 'w') as f:
+    json.dump(ctx, f, indent=2)
+" 2>/dev/null || true
+
+# ── Resolve project directory ──
+LAUNCH_DIR="${HOME}/projects"
+if [[ -n "$PROJECT" ]]; then
+  PROJECT_DIR="${HOME}/projects/${PROJECT}"
+  if [[ -d "$PROJECT_DIR" ]]; then
+    LAUNCH_DIR="$PROJECT_DIR"
+  fi
+fi
+
+# ── Launch claude ──
+cd "$LAUNCH_DIR"
+exec claude --agent "$AGENT_NAME" "${EXTRA_CLAUDE_ARGS[@]}"

--- a/hooks/global/agent-startup.sh
+++ b/hooks/global/agent-startup.sh
@@ -102,10 +102,17 @@ if [[ -f "$DISPATCH_CTX_FILE" ]]; then
     --agent "${CLAUDE_AGENT_NAME}" 2>/dev/null || true
 fi
 
-# Verify Gitea access (non-fatal, quiet)
-GITEA_CHECK=$(curl -sf -o /dev/null -w "%{http_code}" \
-  -u "cheeseburger:xq1Ka03aCQX1ak0qFvTSyOhpwm2gA7oSjASQTkEoB0dXe69zMm9GG" \
-  "https://git.wastelandwares.com/api/v1/version?token=b2922e6ba5274205f0c16829f7aa002d98fe5f7d" 2>/dev/null || echo "000")
+# Verify Gitea access (non-fatal, quiet) — use env vars instead of hardcoded credentials
+GITEA_USER="${GITEA_USER:-}"
+GITEA_PASS="${GITEA_PASS:-}"
+GITEA_TOKEN="${GITEA_TOKEN:-}"
+if [[ -n "$GITEA_USER" && -n "$GITEA_PASS" ]]; then
+  GITEA_CHECK=$(curl -sf -o /dev/null -w "%{http_code}" \
+    -u "${GITEA_USER}:${GITEA_PASS}" \
+    "https://git.wastelandwares.com/api/v1/version?token=${GITEA_TOKEN}" 2>/dev/null || echo "000")
+else
+  GITEA_CHECK="000"
+fi
 
 # Update status to idle (ready for work)
 if type agent_status_update &>/dev/null; then

--- a/hooks/global/agent-startup.sh
+++ b/hooks/global/agent-startup.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+# agent-startup.sh — Called when any agent session begins
+# Registered as a SessionStart hook
+#
+# Responsibilities:
+# 1. Load environment and libraries
+# 2. Detect and persist agent name via CLAUDE_ENV_FILE (#48)
+# 3. Register agent in status system with heartbeat (#48)
+# 4. Read pinboard and inject as context (#53)
+# 5. Read dispatch context and inject for dev-leads (#55)
+# 6. Verify required tools are available
+#
+# Issues resolved: #48, #53, #55
+
+# IMPORTANT: Do NOT use set -euo pipefail here.
+# This hook runs before full session env is available.
+# Any crash = blocked session. Use set +e and exit codes instead.
+set +e
+
+# Read hook input from stdin to extract agent_type and session info
+HOOK_INPUT=$(cat 2>/dev/null || echo '{}')
+HOOK_AGENT_TYPE=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('agent_type',''))" 2>/dev/null || echo "")
+HOOK_SESSION_ID=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('session_id',''))" 2>/dev/null || echo "")
+HOOK_CWD=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || echo "")
+
+# Ensure init.sh is sourced to load all libraries
+if [[ -f "${HOME}/.claude/lib/init.sh" ]]; then
+  source "${HOME}/.claude/lib/init.sh" 2>/dev/null
+fi
+
+# ── Issue #48: Auto-detect and persist agent name ─────────────────────
+# Priority order:
+#   1. CLAUDE_AGENT_NAME already set (e.g. by spawn wrapper)
+#   2. agent_type from hook input (--agent flag or subagent type)
+#   3. Dispatch context file
+#   4. Infer from directory/persona files
+#   5. Fallback: "claude"
+if [[ -z "${CLAUDE_AGENT_NAME:-}" ]]; then
+  if [[ -n "$HOOK_AGENT_TYPE" ]]; then
+    CLAUDE_AGENT_NAME="$HOOK_AGENT_TYPE"
+  elif [[ -f "${HOME}/.claude/state/dispatch-context.json" ]]; then
+    CLAUDE_AGENT_NAME=$(python3 -c "
+import json
+with open('${HOME}/.claude/state/dispatch-context.json') as f:
+    ctx = json.load(f)
+print(ctx.get('agent_name', ''))
+" 2>/dev/null || echo "")
+  fi
+
+  if [[ -z "$CLAUDE_AGENT_NAME" ]]; then
+    # Try to infer from persona file in current session directory
+    if [[ -f "CLAUDE.$(basename "$PWD").md" ]]; then
+      CLAUDE_AGENT_NAME=$(basename "$PWD" | sed 's/.*\.//')
+    else
+      CLAUDE_AGENT_NAME="claude"
+    fi
+  fi
+fi
+export CLAUDE_AGENT_NAME
+
+# Persist CLAUDE_AGENT_NAME via CLAUDE_ENV_FILE so all Bash calls have it (#48)
+if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
+  echo "export CLAUDE_AGENT_NAME=\"${CLAUDE_AGENT_NAME}\"" >> "$CLAUDE_ENV_FILE"
+  # Also persist any dispatch-related env vars
+  if [[ -f "${HOME}/.claude/state/dispatch-context.json" ]]; then
+    DISPATCH_REPO=$(python3 -c "
+import json
+with open('${HOME}/.claude/state/dispatch-context.json') as f:
+    ctx = json.load(f)
+print(ctx.get('repo', ''))
+" 2>/dev/null || echo "")
+    DISPATCH_ISSUE=$(python3 -c "
+import json
+with open('${HOME}/.claude/state/dispatch-context.json') as f:
+    ctx = json.load(f)
+print(ctx.get('issue_number', ''))
+" 2>/dev/null || echo "")
+    if [[ -n "$DISPATCH_REPO" ]]; then
+      echo "export DISPATCH_REPO=\"${DISPATCH_REPO}\"" >> "$CLAUDE_ENV_FILE"
+    fi
+    if [[ -n "$DISPATCH_ISSUE" ]]; then
+      echo "export DISPATCH_ISSUE=\"${DISPATCH_ISSUE}\"" >> "$CLAUDE_ENV_FILE"
+    fi
+  fi
+fi
+
+# Register in status system — create status file automatically (#48)
+if type agent_status_update &>/dev/null; then
+  agent_status_update "starting" "Session initializing" "" "" 2>/dev/null || true
+fi
+
+# ── Issue #53: Read pinboard for context injection ────────────────────
+PINBOARD_CONTEXT=""
+PINBOARD_FILE="${HOME}/.claude/pinboard.json"
+if [[ -f "$PINBOARD_FILE" ]]; then
+  PINBOARD_CONTEXT=$(python3 -c "
+import json, os
+
+pinboard_file = os.path.expanduser('~/.claude/pinboard.json')
+with open(pinboard_file) as f:
+    data = json.load(f)
+
+notes = [p for p in data.get('notes', []) if not p.get('done')]
+if not notes:
+    print('No active pins.')
+else:
+    human_pins = [p for p in notes if p.get('needs_human')]
+    regular_pins = [p for p in notes if not p.get('needs_human')]
+    lines = []
+    if human_pins:
+        lines.append(f'ATTENTION: {len(human_pins)} pin(s) need human response:')
+        for p in human_pins:
+            tag = f' [{p[\"tag\"]}]' if p.get('tag') else ''
+            proj = f' ({p[\"project\"]})' if p.get('project') else ''
+            lines.append(f'  * {p[\"id\"]}: {p[\"text\"][:120]}{tag}{proj}')
+    if regular_pins:
+        lines.append(f'{len(regular_pins)} active pin(s):')
+        for p in regular_pins:
+            tag = f' [{p[\"tag\"]}]' if p.get('tag') else ''
+            proj = f' ({p[\"project\"]})' if p.get('project') else ''
+            lines.append(f'  * {p[\"text\"][:120]}{tag}{proj}')
+    print('\n'.join(lines))
+" 2>/dev/null || echo "")
+fi
+
+# ── Issue #55: Read dispatch context for dev-leads ────────────────────
+DISPATCH_CONTEXT=""
+DISPATCH_CTX_FILE="${HOME}/.claude/state/dispatch-context.json"
+if [[ -f "$DISPATCH_CTX_FILE" ]]; then
+  DISPATCH_CONTEXT=$(python3 -c "
+import json, os, sys
+
+ctx_file = os.path.expanduser('~/.claude/state/dispatch-context.json')
+with open(ctx_file) as f:
+    ctx = json.load(f)
+
+# Only inject if context is fresh (< 5 minutes old) and not already consumed
+import datetime
+created = ctx.get('created_at', '')
+if created:
+    try:
+        created_dt = datetime.datetime.fromisoformat(created.replace('Z', '+00:00'))
+        now = datetime.datetime.now(datetime.timezone.utc)
+        age_sec = (now - created_dt).total_seconds()
+        if age_sec > 300:
+            print('')
+            sys.exit(0)
+    except:
+        pass
+
+# Build context string
+lines = []
+if ctx.get('briefing_summary'):
+    lines.append('## PM Briefing Summary')
+    lines.append(ctx['briefing_summary'])
+    lines.append('')
+
+if ctx.get('issue_bodies'):
+    lines.append('## Issue Details')
+    for issue in ctx['issue_bodies']:
+        lines.append(f'### #{issue.get(\"number\", \"?\")} — {issue.get(\"title\", \"\")}')
+        lines.append(issue.get('body', ''))
+        labels = issue.get('labels', [])
+        if labels:
+            lines.append(f'Labels: {', '.join(labels)}')
+        lines.append('')
+
+if ctx.get('recent_commits'):
+    lines.append('## Recent Commits')
+    lines.append(ctx['recent_commits'])
+    lines.append('')
+
+if ctx.get('cross_dependencies'):
+    lines.append('## Cross-Project Dependencies')
+    lines.append(ctx['cross_dependencies'])
+    lines.append('')
+
+if ctx.get('phase_plan'):
+    lines.append('## Phase Plan')
+    lines.append(ctx['phase_plan'])
+    lines.append('')
+
+if ctx.get('custom_instructions'):
+    lines.append('## Instructions from PM')
+    lines.append(ctx['custom_instructions'])
+    lines.append('')
+
+print('\n'.join(lines))
+" 2>/dev/null || echo "")
+
+  # Mark the dispatch context as consumed so it doesn't re-inject on resume
+  python3 -c "
+import json, os
+ctx_file = os.path.expanduser('~/.claude/state/dispatch-context.json')
+try:
+    with open(ctx_file) as f:
+        ctx = json.load(f)
+    ctx['consumed'] = True
+    ctx['consumed_by'] = '${CLAUDE_AGENT_NAME}'
+    with open(ctx_file, 'w') as f:
+        json.dump(ctx, f, indent=2)
+except:
+    pass
+" 2>/dev/null || true
+fi
+
+# Verify Gitea access (non-fatal, quiet)
+GITEA_CHECK=$(curl -sf -o /dev/null -w "%{http_code}" \
+  -u "cheeseburger:xq1Ka03aCQX1ak0qFvTSyOhpwm2gA7oSjASQTkEoB0dXe69zMm9GG" \
+  "https://git.wastelandwares.com/api/v1/version?token=b2922e6ba5274205f0c16829f7aa002d98fe5f7d" 2>/dev/null || echo "000")
+
+# Update status to idle (ready for work)
+if type agent_status_update &>/dev/null; then
+  agent_status_update "idle" "Ready" "" "" 2>/dev/null || true
+fi
+
+# ── Build output JSON with additionalContext ──────────────────────────
+# SessionStart hooks can return hookSpecificOutput.additionalContext
+# to inject text into the agent's context automatically
+ADDITIONAL_CONTEXT=""
+
+if [[ -n "$PINBOARD_CONTEXT" ]]; then
+  ADDITIONAL_CONTEXT+="<pinboard>
+${PINBOARD_CONTEXT}
+</pinboard>
+"
+fi
+
+if [[ -n "$DISPATCH_CONTEXT" ]]; then
+  ADDITIONAL_CONTEXT+="<dispatch-context>
+${DISPATCH_CONTEXT}
+</dispatch-context>
+"
+fi
+
+# Add agent identity reminder
+ADDITIONAL_CONTEXT+="<agent-metadata>
+Agent: ${CLAUDE_AGENT_NAME}
+Session: ${HOOK_SESSION_ID}
+Libraries pre-loaded: agent-status.sh, agent-tx.sh, gitea-api.sh (via CLAUDE_ENV_FILE)
+CLAUDE_AGENT_NAME is set in your environment — no need to export it manually.
+</agent-metadata>"
+
+if [[ -n "$ADDITIONAL_CONTEXT" ]]; then
+  # Use python to safely JSON-encode the context string
+  python3 -c "
+import json, sys
+
+context = sys.stdin.read()
+output = {
+    'hookSpecificOutput': {
+        'hookEventName': 'SessionStart',
+        'additionalContext': context
+    }
+}
+print(json.dumps(output))
+" <<< "$ADDITIONAL_CONTEXT"
+else
+  echo '{}'
+fi
+
+exit 0

--- a/hooks/global/agent-startup.sh
+++ b/hooks/global/agent-startup.sh
@@ -17,11 +17,14 @@
 # Any crash = blocked session. Use set +e and exit codes instead.
 set +e
 
+_WW_JSON="${HOME}/.claude/bin/ww-json-tool.py"
+
 # Read hook input from stdin to extract agent_type and session info
 HOOK_INPUT=$(cat 2>/dev/null || echo '{}')
-HOOK_AGENT_TYPE=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('agent_type',''))" 2>/dev/null || echo "")
-HOOK_SESSION_ID=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('session_id',''))" 2>/dev/null || echo "")
-HOOK_CWD=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || echo "")
+eval "$(echo "$HOOK_INPUT" | "$_WW_JSON" hook parse-input --keys agent_type session_id cwd 2>/dev/null || echo "")"
+HOOK_AGENT_TYPE="${agent_type:-}"
+HOOK_SESSION_ID="${session_id:-}"
+HOOK_CWD="${cwd:-}"
 
 # Ensure init.sh is sourced to load all libraries
 if [[ -f "${HOME}/.claude/lib/init.sh" ]]; then
@@ -39,12 +42,9 @@ if [[ -z "${CLAUDE_AGENT_NAME:-}" ]]; then
   if [[ -n "$HOOK_AGENT_TYPE" ]]; then
     CLAUDE_AGENT_NAME="$HOOK_AGENT_TYPE"
   elif [[ -f "${HOME}/.claude/state/dispatch-context.json" ]]; then
-    CLAUDE_AGENT_NAME=$(python3 -c "
-import json
-with open('${HOME}/.claude/state/dispatch-context.json') as f:
-    ctx = json.load(f)
-print(ctx.get('agent_name', ''))
-" 2>/dev/null || echo "")
+    CLAUDE_AGENT_NAME=$("$_WW_JSON" json get \
+      --file "${HOME}/.claude/state/dispatch-context.json" \
+      --key agent_name --default "" 2>/dev/null || echo "")
   fi
 
   if [[ -z "$CLAUDE_AGENT_NAME" ]]; then
@@ -63,18 +63,12 @@ if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
   echo "export CLAUDE_AGENT_NAME=\"${CLAUDE_AGENT_NAME}\"" >> "$CLAUDE_ENV_FILE"
   # Also persist any dispatch-related env vars
   if [[ -f "${HOME}/.claude/state/dispatch-context.json" ]]; then
-    DISPATCH_REPO=$(python3 -c "
-import json
-with open('${HOME}/.claude/state/dispatch-context.json') as f:
-    ctx = json.load(f)
-print(ctx.get('repo', ''))
-" 2>/dev/null || echo "")
-    DISPATCH_ISSUE=$(python3 -c "
-import json
-with open('${HOME}/.claude/state/dispatch-context.json') as f:
-    ctx = json.load(f)
-print(ctx.get('issue_number', ''))
-" 2>/dev/null || echo "")
+    DISPATCH_REPO=$("$_WW_JSON" json get \
+      --file "${HOME}/.claude/state/dispatch-context.json" \
+      --key repo --default "" 2>/dev/null || echo "")
+    DISPATCH_ISSUE=$("$_WW_JSON" json get \
+      --file "${HOME}/.claude/state/dispatch-context.json" \
+      --key issue_number --default "" 2>/dev/null || echo "")
     if [[ -n "$DISPATCH_REPO" ]]; then
       echo "export DISPATCH_REPO=\"${DISPATCH_REPO}\"" >> "$CLAUDE_ENV_FILE"
     fi
@@ -93,115 +87,19 @@ fi
 PINBOARD_CONTEXT=""
 PINBOARD_FILE="${HOME}/.claude/pinboard.json"
 if [[ -f "$PINBOARD_FILE" ]]; then
-  PINBOARD_CONTEXT=$(python3 -c "
-import json, os
-
-pinboard_file = os.path.expanduser('~/.claude/pinboard.json')
-with open(pinboard_file) as f:
-    data = json.load(f)
-
-notes = [p for p in data.get('notes', []) if not p.get('done')]
-if not notes:
-    print('No active pins.')
-else:
-    human_pins = [p for p in notes if p.get('needs_human')]
-    regular_pins = [p for p in notes if not p.get('needs_human')]
-    lines = []
-    if human_pins:
-        lines.append(f'ATTENTION: {len(human_pins)} pin(s) need human response:')
-        for p in human_pins:
-            tag = f' [{p[\"tag\"]}]' if p.get('tag') else ''
-            proj = f' ({p[\"project\"]})' if p.get('project') else ''
-            lines.append(f'  * {p[\"id\"]}: {p[\"text\"][:120]}{tag}{proj}')
-    if regular_pins:
-        lines.append(f'{len(regular_pins)} active pin(s):')
-        for p in regular_pins:
-            tag = f' [{p[\"tag\"]}]' if p.get('tag') else ''
-            proj = f' ({p[\"project\"]})' if p.get('project') else ''
-            lines.append(f'  * {p[\"text\"][:120]}{tag}{proj}')
-    print('\n'.join(lines))
-" 2>/dev/null || echo "")
+  PINBOARD_CONTEXT=$("$_WW_JSON" pin read-context --file "$PINBOARD_FILE" 2>/dev/null || echo "")
 fi
 
 # ── Issue #55: Read dispatch context for dev-leads ────────────────────
 DISPATCH_CONTEXT=""
 DISPATCH_CTX_FILE="${HOME}/.claude/state/dispatch-context.json"
 if [[ -f "$DISPATCH_CTX_FILE" ]]; then
-  DISPATCH_CONTEXT=$(python3 -c "
-import json, os, sys
-
-ctx_file = os.path.expanduser('~/.claude/state/dispatch-context.json')
-with open(ctx_file) as f:
-    ctx = json.load(f)
-
-# Only inject if context is fresh (< 5 minutes old) and not already consumed
-import datetime
-created = ctx.get('created_at', '')
-if created:
-    try:
-        created_dt = datetime.datetime.fromisoformat(created.replace('Z', '+00:00'))
-        now = datetime.datetime.now(datetime.timezone.utc)
-        age_sec = (now - created_dt).total_seconds()
-        if age_sec > 300:
-            print('')
-            sys.exit(0)
-    except:
-        pass
-
-# Build context string
-lines = []
-if ctx.get('briefing_summary'):
-    lines.append('## PM Briefing Summary')
-    lines.append(ctx['briefing_summary'])
-    lines.append('')
-
-if ctx.get('issue_bodies'):
-    lines.append('## Issue Details')
-    for issue in ctx['issue_bodies']:
-        lines.append(f'### #{issue.get(\"number\", \"?\")} — {issue.get(\"title\", \"\")}')
-        lines.append(issue.get('body', ''))
-        labels = issue.get('labels', [])
-        if labels:
-            lines.append(f'Labels: {', '.join(labels)}')
-        lines.append('')
-
-if ctx.get('recent_commits'):
-    lines.append('## Recent Commits')
-    lines.append(ctx['recent_commits'])
-    lines.append('')
-
-if ctx.get('cross_dependencies'):
-    lines.append('## Cross-Project Dependencies')
-    lines.append(ctx['cross_dependencies'])
-    lines.append('')
-
-if ctx.get('phase_plan'):
-    lines.append('## Phase Plan')
-    lines.append(ctx['phase_plan'])
-    lines.append('')
-
-if ctx.get('custom_instructions'):
-    lines.append('## Instructions from PM')
-    lines.append(ctx['custom_instructions'])
-    lines.append('')
-
-print('\n'.join(lines))
-" 2>/dev/null || echo "")
+  DISPATCH_CONTEXT=$("$_WW_JSON" hook read-dispatch-context --file "$DISPATCH_CTX_FILE" 2>/dev/null || echo "")
 
   # Mark the dispatch context as consumed so it doesn't re-inject on resume
-  python3 -c "
-import json, os
-ctx_file = os.path.expanduser('~/.claude/state/dispatch-context.json')
-try:
-    with open(ctx_file) as f:
-        ctx = json.load(f)
-    ctx['consumed'] = True
-    ctx['consumed_by'] = '${CLAUDE_AGENT_NAME}'
-    with open(ctx_file, 'w') as f:
-        json.dump(ctx, f, indent=2)
-except:
-    pass
-" 2>/dev/null || true
+  "$_WW_JSON" dispatch consume-context \
+    --file "$DISPATCH_CTX_FILE" \
+    --agent "${CLAUDE_AGENT_NAME}" 2>/dev/null || true
 fi
 
 # Verify Gitea access (non-fatal, quiet)
@@ -242,19 +140,7 @@ CLAUDE_AGENT_NAME is set in your environment — no need to export it manually.
 </agent-metadata>"
 
 if [[ -n "$ADDITIONAL_CONTEXT" ]]; then
-  # Use python to safely JSON-encode the context string
-  python3 -c "
-import json, sys
-
-context = sys.stdin.read()
-output = {
-    'hookSpecificOutput': {
-        'hookEventName': 'SessionStart',
-        'additionalContext': context
-    }
-}
-print(json.dumps(output))
-" <<< "$ADDITIONAL_CONTEXT"
+  echo "$ADDITIONAL_CONTEXT" | "$_WW_JSON" hook build-output --event-name "SessionStart"
 else
   echo '{}'
 fi

--- a/hooks/global/subagent-start.sh
+++ b/hooks/global/subagent-start.sh
@@ -12,12 +12,15 @@
 
 set +e
 
+_WW_JSON="${HOME}/.claude/bin/ww-json-tool.py"
+
 # Read hook input
 HOOK_INPUT=$(cat 2>/dev/null || echo '{}')
-AGENT_TYPE=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('agent_type',''))" 2>/dev/null || echo "unknown")
-AGENT_ID=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('agent_id',''))" 2>/dev/null || echo "")
-SESSION_ID=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('session_id',''))" 2>/dev/null || echo "")
-CWD=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || echo "")
+eval "$(echo "$HOOK_INPUT" | "$_WW_JSON" hook parse-input --keys agent_type agent_id session_id cwd 2>/dev/null || echo "")"
+AGENT_TYPE="${agent_type:-unknown}"
+AGENT_ID="${agent_id:-}"
+SESSION_ID="${session_id:-}"
+CWD="${cwd:-}"
 
 # Source libraries
 if [[ -f "${HOME}/.claude/lib/init.sh" ]]; then
@@ -62,22 +65,18 @@ CONTEXT_LINES=""
 # Include dispatch context if available
 DISPATCH_CTX_FILE="${HOME}/.claude/state/dispatch-context.json"
 if [[ -f "$DISPATCH_CTX_FILE" ]]; then
-  DISPATCH_SUMMARY=$(python3 -c "
-import json, os
-ctx_file = os.path.expanduser('~/.claude/state/dispatch-context.json')
-with open(ctx_file) as f:
-    ctx = json.load(f)
-# Only include if not consumed or if custom_instructions exist
-if ctx.get('custom_instructions'):
-    print(ctx['custom_instructions'])
-elif ctx.get('briefing_summary'):
-    # Abbreviated version for subagents
-    print(ctx['briefing_summary'][:500])
-" 2>/dev/null || echo "")
-  if [[ -n "$DISPATCH_SUMMARY" ]]; then
+  # Read custom_instructions or briefing_summary for subagent context
+  DISPATCH_INSTRUCTIONS=$("$_WW_JSON" json get \
+    --file "$DISPATCH_CTX_FILE" --key custom_instructions --default "" 2>/dev/null || echo "")
+  if [[ -z "$DISPATCH_INSTRUCTIONS" ]]; then
+    DISPATCH_BRIEFING=$("$_WW_JSON" json get \
+      --file "$DISPATCH_CTX_FILE" --key briefing_summary --default "" 2>/dev/null || echo "")
+    DISPATCH_INSTRUCTIONS="${DISPATCH_BRIEFING:0:500}"
+  fi
+  if [[ -n "$DISPATCH_INSTRUCTIONS" ]]; then
     CONTEXT_LINES+="<parent-context>
 Dispatched by: ${PARENT_AGENT}
-${DISPATCH_SUMMARY}
+${DISPATCH_INSTRUCTIONS}
 </parent-context>
 "
   fi
@@ -92,17 +91,7 @@ Libraries available: agent-status.sh, agent-tx.sh, gitea-api.sh
 </agent-metadata>"
 
 if [[ -n "$CONTEXT_LINES" ]]; then
-  python3 -c "
-import json, sys
-context = sys.stdin.read()
-output = {
-    'hookSpecificOutput': {
-        'hookEventName': 'SubagentStart',
-        'additionalContext': context
-    }
-}
-print(json.dumps(output))
-" <<< "$CONTEXT_LINES"
+  echo "$CONTEXT_LINES" | "$_WW_JSON" hook build-output --event-name "SubagentStart"
 else
   echo '{}'
 fi

--- a/hooks/global/subagent-start.sh
+++ b/hooks/global/subagent-start.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# subagent-start.sh — Called when a subagent is spawned
+# Registered as a SubagentStart hook
+#
+# Issue #54: Auto-fire tx_begin when subagent spawns
+#
+# This hook:
+# 1. Reads the subagent's agent_type and agent_id from stdin
+# 2. Starts a transaction (tx_begin) automatically
+# 3. Sets the subagent's CLAUDE_AGENT_NAME
+# 4. Injects context including pinboard and dispatch info
+
+set +e
+
+# Read hook input
+HOOK_INPUT=$(cat 2>/dev/null || echo '{}')
+AGENT_TYPE=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('agent_type',''))" 2>/dev/null || echo "unknown")
+AGENT_ID=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('agent_id',''))" 2>/dev/null || echo "")
+SESSION_ID=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('session_id',''))" 2>/dev/null || echo "")
+CWD=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || echo "")
+
+# Source libraries
+if [[ -f "${HOME}/.claude/lib/init.sh" ]]; then
+  source "${HOME}/.claude/lib/init.sh" 2>/dev/null
+fi
+
+# Set agent name for this subagent
+PARENT_AGENT="${CLAUDE_AGENT_NAME:-unknown}"
+export CLAUDE_AGENT_NAME="sub-${AGENT_TYPE}-$$"
+
+# ── Auto tx_begin (#54) ──────────────────────────────────────────────
+# Start a transaction automatically for the subagent
+# Skip for built-in lightweight agents (Explore, Plan, Bash) that are
+# quick lookups, not real work sessions
+case "$AGENT_TYPE" in
+  Bash|Explore|Plan|Glob|Grep|Read|Edit|Write)
+    # Skip tx for built-in tool-like agents — they're lightweight
+    ;;
+  *)
+    # Real subagent (dev-lead, test-agent, etc.) — start a transaction
+    if type tx_begin &>/dev/null; then
+      # Detect repo from cwd
+      REPO=""
+      if [[ -n "$CWD" ]]; then
+        REPO=$(cd "$CWD" 2>/dev/null && git remote get-url origin 2>/dev/null | sed 's|.*/||;s|\.git$||' || echo "")
+        if [[ -n "$REPO" ]]; then
+          REPO="tquick/$REPO"
+        fi
+      fi
+
+      tx_begin "Subagent task: ${AGENT_TYPE}" \
+               "Auto-dispatched by ${PARENT_AGENT}" \
+               "$REPO" \
+               "" 2>/dev/null || true
+    fi
+    ;;
+esac
+
+# ── Build additionalContext for the subagent ──────────────────────────
+CONTEXT_LINES=""
+
+# Include dispatch context if available
+DISPATCH_CTX_FILE="${HOME}/.claude/state/dispatch-context.json"
+if [[ -f "$DISPATCH_CTX_FILE" ]]; then
+  DISPATCH_SUMMARY=$(python3 -c "
+import json, os
+ctx_file = os.path.expanduser('~/.claude/state/dispatch-context.json')
+with open(ctx_file) as f:
+    ctx = json.load(f)
+# Only include if not consumed or if custom_instructions exist
+if ctx.get('custom_instructions'):
+    print(ctx['custom_instructions'])
+elif ctx.get('briefing_summary'):
+    # Abbreviated version for subagents
+    print(ctx['briefing_summary'][:500])
+" 2>/dev/null || echo "")
+  if [[ -n "$DISPATCH_SUMMARY" ]]; then
+    CONTEXT_LINES+="<parent-context>
+Dispatched by: ${PARENT_AGENT}
+${DISPATCH_SUMMARY}
+</parent-context>
+"
+  fi
+fi
+
+# Agent metadata
+CONTEXT_LINES+="<agent-metadata>
+Agent: ${CLAUDE_AGENT_NAME} (subagent of ${PARENT_AGENT})
+Transaction started automatically — no need to call tx_begin.
+Use tx_action to log significant changes. tx_end will fire on SubagentStop.
+Libraries available: agent-status.sh, agent-tx.sh, gitea-api.sh
+</agent-metadata>"
+
+if [[ -n "$CONTEXT_LINES" ]]; then
+  python3 -c "
+import json, sys
+context = sys.stdin.read()
+output = {
+    'hookSpecificOutput': {
+        'hookEventName': 'SubagentStart',
+        'additionalContext': context
+    }
+}
+print(json.dumps(output))
+" <<< "$CONTEXT_LINES"
+else
+  echo '{}'
+fi
+
+exit 0

--- a/hooks/global/subagent-start.sh
+++ b/hooks/global/subagent-start.sh
@@ -29,7 +29,7 @@ fi
 
 # Set agent name for this subagent
 PARENT_AGENT="${CLAUDE_AGENT_NAME:-unknown}"
-export CLAUDE_AGENT_NAME="sub-${AGENT_TYPE}-$$"
+export CLAUDE_AGENT_NAME="sub-${AGENT_TYPE}-${AGENT_ID}"
 
 # ── Auto tx_begin (#54) ──────────────────────────────────────────────
 # Start a transaction automatically for the subagent

--- a/hooks/global/subagent-stop.sh
+++ b/hooks/global/subagent-stop.sh
@@ -14,9 +14,11 @@ _WW_JSON="${HOME}/.claude/bin/ww-json-tool.py"
 
 # Read hook input
 HOOK_INPUT=$(cat 2>/dev/null || echo '{}')
-eval "$(echo "$HOOK_INPUT" | "$_WW_JSON" hook parse-input --keys agent_type agent_id 2>/dev/null || echo "")"
+eval "$(echo "$HOOK_INPUT" | "$_WW_JSON" hook parse-input --keys agent_type agent_id exit_code outcome 2>/dev/null || echo "")"
 AGENT_TYPE="${agent_type:-unknown}"
 AGENT_ID="${agent_id:-}"
+EXIT_CODE="${exit_code:-1}"
+OUTCOME="${outcome:-}"
 
 # Source libraries
 if [[ -f "${HOME}/.claude/lib/init.sh" ]]; then
@@ -36,7 +38,12 @@ export CLAUDE_AGENT_NAME="sub-${AGENT_TYPE}-${AGENT_ID}"
 
 # Auto tx_end (#54)
 if type tx_end &>/dev/null; then
-  tx_end "success" "Subagent ${AGENT_TYPE} completed" 2>/dev/null || true
+  # Determine outcome based on exit code or outcome field
+  TX_OUTCOME="failed"
+  if [[ "$EXIT_CODE" == "0" ]] || [[ "$OUTCOME" == "success" ]]; then
+    TX_OUTCOME="success"
+  fi
+  tx_end "$TX_OUTCOME" "Subagent ${AGENT_TYPE} completed with exit code ${EXIT_CODE}" 2>/dev/null || true
 fi
 
 # Clear status

--- a/hooks/global/subagent-stop.sh
+++ b/hooks/global/subagent-stop.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# subagent-stop.sh — Called when a subagent finishes
+# Registered as a SubagentStop hook
+#
+# Issue #54: Auto-fire tx_end when subagent completes
+#
+# This hook:
+# 1. Ends any active transaction for the subagent
+# 2. Clears the subagent's status
+
+set +e
+
+# Read hook input
+HOOK_INPUT=$(cat 2>/dev/null || echo '{}')
+AGENT_TYPE=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('agent_type',''))" 2>/dev/null || echo "unknown")
+AGENT_ID=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('agent_id',''))" 2>/dev/null || echo "")
+
+# Source libraries
+if [[ -f "${HOME}/.claude/lib/init.sh" ]]; then
+  source "${HOME}/.claude/lib/init.sh" 2>/dev/null
+fi
+
+# Skip for built-in lightweight agents
+case "$AGENT_TYPE" in
+  Bash|Explore|Plan|Glob|Grep|Read|Edit|Write)
+    echo '{}'
+    exit 0
+    ;;
+esac
+
+# Set agent name to match what SubagentStart set
+export CLAUDE_AGENT_NAME="sub-${AGENT_TYPE}-$$"
+
+# Auto tx_end (#54)
+if type tx_end &>/dev/null; then
+  tx_end "success" "Subagent ${AGENT_TYPE} completed" 2>/dev/null || true
+fi
+
+# Clear status
+if type agent_status_clear &>/dev/null; then
+  agent_status_clear 2>/dev/null || true
+fi
+
+echo '{}'
+exit 0

--- a/hooks/global/subagent-stop.sh
+++ b/hooks/global/subagent-stop.sh
@@ -10,10 +10,13 @@
 
 set +e
 
+_WW_JSON="${HOME}/.claude/bin/ww-json-tool.py"
+
 # Read hook input
 HOOK_INPUT=$(cat 2>/dev/null || echo '{}')
-AGENT_TYPE=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('agent_type',''))" 2>/dev/null || echo "unknown")
-AGENT_ID=$(echo "$HOOK_INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('agent_id',''))" 2>/dev/null || echo "")
+eval "$(echo "$HOOK_INPUT" | "$_WW_JSON" hook parse-input --keys agent_type agent_id 2>/dev/null || echo "")"
+AGENT_TYPE="${agent_type:-unknown}"
+AGENT_ID="${agent_id:-}"
 
 # Source libraries
 if [[ -f "${HOME}/.claude/lib/init.sh" ]]; then

--- a/hooks/global/subagent-stop.sh
+++ b/hooks/global/subagent-stop.sh
@@ -32,7 +32,7 @@ case "$AGENT_TYPE" in
 esac
 
 # Set agent name to match what SubagentStart set
-export CLAUDE_AGENT_NAME="sub-${AGENT_TYPE}-$$"
+export CLAUDE_AGENT_NAME="sub-${AGENT_TYPE}-${AGENT_ID}"
 
 # Auto tx_end (#54)
 if type tx_end &>/dev/null; then

--- a/hooks/pretooluse.py
+++ b/hooks/pretooluse.py
@@ -91,7 +91,7 @@ def check_worktree_isolation(command: str) -> dict | None:
             "decision": "allow",
             "systemMessage": (
                 "WARNING: Dev agents should work in worktrees, not the main working tree. "
-                "Use: git worktree add ../.worktrees/{story-id} -b {branch-name}"
+                "Use: git worktree add ../.worktrees/{task-id} -b {branch-name}"
             ),
         }
 

--- a/lib/agent_status.py
+++ b/lib/agent_status.py
@@ -8,7 +8,7 @@ Usage (from hooks or scripts):
     from lib.agent_status import AgentStatus
 
     status = AgentStatus("pm")
-    status.update("working", "Planning sprint 2", repo="tquick/meeting-scribe", issue=17)
+    status.update("working", "Planning phase 2", repo="tquick/meeting-scribe", issue=17)
     status.heartbeat()
     status.clear()
 """

--- a/lib/agent_tx.py
+++ b/lib/agent_tx.py
@@ -7,7 +7,7 @@ Usage:
     from lib.agent_tx import Transaction
 
     tx = Transaction("pm")
-    tx.begin("Implementing rolling summary", "Sprint 1 story #18", repo="tquick/meeting-scribe", issue=18)
+    tx.begin("Implementing rolling summary", "Phase 1 task #18", repo="tquick/meeting-scribe", issue=18)
     tx.action("Created src/summary_prompt.py", "Prompt template for condensed meeting minutes")
     tx.action("Updated pipeline.py", "Integrated summary into batch loop")
     tx.end("success", "Rolling summary working")

--- a/lib/conflict.py
+++ b/lib/conflict.py
@@ -1,14 +1,14 @@
 """Conflict detection via file ownership.
 
-Analyzes a sprint manifest to detect stories that touch the same files.
-Stories with overlapping file ownership must be serialized (not run in
+Analyzes a phase manifest to detect tasks that touch the same files.
+Tasks with overlapping file ownership must be serialized (not run in
 parallel) to prevent merge conflicts.
 
 Usage:
     from lib.conflict import detect_conflicts, apply_serialization
-    from lib.manifest import SprintManifest
+    from lib.manifest import PhaseManifest
 
-    manifest = SprintManifest.from_yaml("sprint.yaml")
+    manifest = PhaseManifest.from_yaml("phase.yaml")
     conflicts = detect_conflicts(manifest)
     if conflicts:
         apply_serialization(manifest, conflicts)
@@ -20,43 +20,43 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Optional
 
-from lib.manifest import SprintManifest
+from lib.manifest import PhaseManifest
 
 
 @dataclass
 class FileConflict:
-    """A conflict where multiple stories touch the same file."""
+    """A conflict where multiple tasks touch the same file."""
 
     file_path: str
-    story_ids: list[str]
+    task_ids: list[str]
 
 
-def build_ownership_map(manifest: SprintManifest) -> dict[str, list[str]]:
-    """Build a map of file -> list of story IDs that touch it."""
+def build_ownership_map(manifest: PhaseManifest) -> dict[str, list[str]]:
+    """Build a map of file -> list of task IDs that touch it."""
     ownership: dict[str, list[str]] = defaultdict(list)
-    for story in manifest.stories:
-        for f in story.files:
-            ownership[f].append(story.id)
+    for task in manifest.tasks:
+        for f in task.files:
+            ownership[f].append(task.id)
     return dict(ownership)
 
 
-def detect_conflicts(manifest: SprintManifest) -> list[FileConflict]:
-    """Find files touched by multiple stories."""
+def detect_conflicts(manifest: PhaseManifest) -> list[FileConflict]:
+    """Find files touched by multiple tasks."""
     ownership = build_ownership_map(manifest)
     conflicts = []
-    for file_path, story_ids in ownership.items():
-        if len(story_ids) > 1:
-            conflicts.append(FileConflict(file_path=file_path, story_ids=story_ids))
+    for file_path, task_ids in ownership.items():
+        if len(task_ids) > 1:
+            conflicts.append(FileConflict(file_path=file_path, task_ids=task_ids))
     return conflicts
 
 
 def apply_serialization(
-    manifest: SprintManifest,
+    manifest: PhaseManifest,
     conflicts: Optional[list[FileConflict]] = None,
 ) -> list[FileConflict]:
-    """Add dependency edges to serialize conflicting stories.
+    """Add dependency edges to serialize conflicting tasks.
 
-    For each conflict, the story with the higher issue number gets a
+    For each conflict, the task with the higher issue number gets a
     dependency on the lower one, ensuring sequential execution.
 
     Returns the conflicts that were resolved.
@@ -67,18 +67,18 @@ def apply_serialization(
     if not conflicts:
         return []
 
-    # Build a lookup for stories
-    story_map = {s.id: s for s in manifest.stories}
+    # Build a lookup for tasks
+    task_map = {s.id: s for s in manifest.tasks}
 
     for conflict in conflicts:
-        # Sort by issue number (or story ID) to get deterministic ordering
+        # Sort by issue number (or task ID) to get deterministic ordering
         sorted_ids = sorted(
-            conflict.story_ids,
-            key=lambda sid: story_map[sid].issue or 0,
+            conflict.task_ids,
+            key=lambda sid: task_map[sid].issue or 0,
         )
-        # Chain them: each story depends on the previous one
+        # Chain them: each task depends on the previous one
         for i in range(1, len(sorted_ids)):
-            later = story_map[sorted_ids[i]]
+            later = task_map[sorted_ids[i]]
             earlier_id = sorted_ids[i - 1]
             if earlier_id not in later.depends_on:
                 later.depends_on.append(earlier_id)
@@ -93,4 +93,4 @@ def print_conflicts(conflicts: list[FileConflict]) -> None:
         return
     print(f"[conflict] {len(conflicts)} file conflict(s) detected:")
     for c in conflicts:
-        print(f"  {c.file_path}: {', '.join(c.story_ids)}")
+        print(f"  {c.file_path}: {', '.join(c.task_ids)}")

--- a/lib/cook.sh
+++ b/lib/cook.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# cook.sh — Shell helpers for "Let Claude Cook" mode
+#
+# Source in agent sessions:
+#   source ~/.claude/lib/cook.sh
+#
+# Functions:
+#   cook_is_active       — returns 0 if cook mode active, 1 if not
+#   cook_activate        — writes state file, prints confirmation
+#   cook_deactivate      — clears state, prints summary
+#   cook_queue_message   — wraps btw queue with cook-mode tagging
+#   cook_check_exit      — checks if a message contains exit keywords
+
+COOK_STATE_FILE="${HOME}/.claude/state/cook-mode.json"
+
+# Ensure state dir exists
+mkdir -p "$(dirname "$COOK_STATE_FILE")" 2>/dev/null
+
+cook_is_active() {
+  if [[ ! -f "$COOK_STATE_FILE" ]]; then
+    return 1
+  fi
+  local active
+  active=$(python3 -c "
+import json, os
+try:
+    with open(os.path.expanduser('$COOK_STATE_FILE')) as f:
+        data = json.load(f)
+    print('yes' if data.get('active', False) else 'no')
+except:
+    print('no')
+" 2>/dev/null)
+  [[ "$active" == "yes" ]]
+}
+
+cook_activate() {
+  local task="${1:-Autonomous work session}"
+  python3 << PYEOF
+import json, os, datetime
+
+state = {
+    "active": True,
+    "started_at": datetime.datetime.now().isoformat(),
+    "task": """${task}""",
+    "messages_queued": 0,
+    "exit_keywords": ["stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"]
+}
+
+os.makedirs(os.path.dirname("$COOK_STATE_FILE"), exist_ok=True)
+with open("$COOK_STATE_FILE", "w") as f:
+    json.dump(state, f, indent=2)
+
+print("🔥 LET HIM COOK — Cook mode activated!")
+print(f"   Task: {state['task']}")
+print(f"   Started: {state['started_at'][:19]}")
+print("   User messages will be queued as btw items.")
+print("   Say 'stop', 'pause', or 'hey' to exit cook mode.")
+PYEOF
+}
+
+cook_deactivate() {
+  if [[ ! -f "$COOK_STATE_FILE" ]]; then
+    echo "Cook mode is not active."
+    return 1
+  fi
+
+  python3 << 'PYEOF'
+import json, os, datetime
+
+state_file = os.path.expanduser("~/.claude/state/cook-mode.json")
+btw_file = os.path.expanduser("~/.claude/btw-queue.json")
+
+try:
+    with open(state_file) as f:
+        state = json.load(f)
+except:
+    print("Cook mode is not active.")
+    exit(1)
+
+if not state.get("active"):
+    print("Cook mode is not active.")
+    exit(1)
+
+started = state.get("started_at", "unknown")
+queued = state.get("messages_queued", 0)
+task = state.get("task", "unknown")
+
+# Read queued btw items tagged with cook-mode
+cook_items = []
+try:
+    with open(btw_file) as f:
+        btw = json.load(f)
+    cook_items = [i for i in btw["items"]
+                  if not i.get("processed") and i.get("cook_mode")]
+except:
+    pass
+
+# Deactivate
+state["active"] = False
+state["ended_at"] = datetime.datetime.now().isoformat()
+with open(state_file, "w") as f:
+    json.dump(state, f, indent=2)
+
+print("🍳 Cook mode deactivated!")
+print(f"   Task: {task}")
+print(f"   Session started: {started[:19]}")
+print(f"   Messages queued: {queued}")
+
+if cook_items:
+    print("\n   Queued messages:")
+    for i, item in enumerate(cook_items, 1):
+        ts = item.get("timestamp", "?")[:16]
+        print(f"   {i}. [{ts}] {item['text']}")
+    print(f"\n   Process these with: btw  (or btw_read)")
+else:
+    print("   No messages were queued during this session.")
+PYEOF
+}
+
+cook_queue_message() {
+  local message="$*"
+  if [[ -z "$message" ]]; then
+    echo "No message to queue."
+    return 1
+  fi
+
+  python3 << PYEOF
+import json, os, datetime
+
+btw_file = os.path.expanduser("~/.claude/btw-queue.json")
+state_file = os.path.expanduser("~/.claude/state/cook-mode.json")
+
+# Ensure btw file exists
+if not os.path.exists(btw_file):
+    with open(btw_file, "w") as f:
+        json.dump({"items": [], "processed": []}, f)
+
+with open(btw_file) as f:
+    btw = json.load(f)
+
+btw["items"].append({
+    "text": """${message}""",
+    "timestamp": datetime.datetime.now().isoformat(),
+    "processed": False,
+    "cook_mode": True,
+})
+
+with open(btw_file, "w") as f:
+    json.dump(btw, f, indent=2)
+
+# Update cook state counter
+try:
+    with open(state_file) as f:
+        state = json.load(f)
+    state["messages_queued"] = state.get("messages_queued", 0) + 1
+    with open(state_file, "w") as f:
+        json.dump(state, f, indent=2)
+except:
+    pass
+
+count = len([i for i in btw["items"] if not i.get("processed")])
+print(f"📝 Queued ({count} pending)")
+PYEOF
+}
+
+cook_check_exit() {
+  local message="$*"
+  local message_lower
+  message_lower=$(echo "$message" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+  # Check against exit keywords
+  python3 << PYEOF
+import json, os
+
+state_file = os.path.expanduser("~/.claude/state/cook-mode.json")
+msg = """${message_lower}""".strip().lower()
+
+try:
+    with open(state_file) as f:
+        state = json.load(f)
+    keywords = state.get("exit_keywords", ["stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"])
+except:
+    keywords = ["stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"]
+
+# Exact match or starts-with for multi-word keywords
+for kw in keywords:
+    if msg == kw or msg.startswith(kw + " ") or msg.startswith(kw + ",") or msg.startswith(kw + "."):
+        print("exit")
+        exit(0)
+
+# Also check /uncook command
+if msg.strip().startswith("/uncook"):
+    print("exit")
+    exit(0)
+
+print("continue")
+PYEOF
+}

--- a/lib/cook.sh
+++ b/lib/cook.sh
@@ -12,6 +12,7 @@
 #   cook_check_exit      — checks if a message contains exit keywords
 
 COOK_STATE_FILE="${HOME}/.claude/state/cook-mode.json"
+_WW_JSON="${HOME}/.claude/bin/ww-json-tool.py"
 
 # Ensure state dir exists
 mkdir -p "$(dirname "$COOK_STATE_FILE")" 2>/dev/null
@@ -21,41 +22,15 @@ cook_is_active() {
     return 1
   fi
   local active
-  active=$(python3 -c "
-import json, os
-try:
-    with open(os.path.expanduser('$COOK_STATE_FILE')) as f:
-        data = json.load(f)
-    print('yes' if data.get('active', False) else 'no')
-except:
-    print('no')
-" 2>/dev/null)
+  active=$("$_WW_JSON" cook read --file "$COOK_STATE_FILE" 2>/dev/null)
   [[ "$active" == "yes" ]]
 }
 
 cook_activate() {
   local task="${1:-Autonomous work session}"
-  python3 << PYEOF
-import json, os, datetime
-
-state = {
-    "active": True,
-    "started_at": datetime.datetime.now().isoformat(),
-    "task": """${task}""",
-    "messages_queued": 0,
-    "exit_keywords": ["stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"]
-}
-
-os.makedirs(os.path.dirname("$COOK_STATE_FILE"), exist_ok=True)
-with open("$COOK_STATE_FILE", "w") as f:
-    json.dump(state, f, indent=2)
-
-print("🔥 LET HIM COOK — Cook mode activated!")
-print(f"   Task: {state['task']}")
-print(f"   Started: {state['started_at'][:19]}")
-print("   User messages will be queued as btw items.")
-print("   Say 'stop', 'pause', or 'hey' to exit cook mode.")
-PYEOF
+  "$_WW_JSON" cook activate \
+    --file "$COOK_STATE_FILE" \
+    --task "$task"
 }
 
 cook_deactivate() {
@@ -64,57 +39,9 @@ cook_deactivate() {
     return 1
   fi
 
-  python3 << 'PYEOF'
-import json, os, datetime
-
-state_file = os.path.expanduser("~/.claude/state/cook-mode.json")
-btw_file = os.path.expanduser("~/.claude/btw-queue.json")
-
-try:
-    with open(state_file) as f:
-        state = json.load(f)
-except:
-    print("Cook mode is not active.")
-    exit(1)
-
-if not state.get("active"):
-    print("Cook mode is not active.")
-    exit(1)
-
-started = state.get("started_at", "unknown")
-queued = state.get("messages_queued", 0)
-task = state.get("task", "unknown")
-
-# Read queued btw items tagged with cook-mode
-cook_items = []
-try:
-    with open(btw_file) as f:
-        btw = json.load(f)
-    cook_items = [i for i in btw["items"]
-                  if not i.get("processed") and i.get("cook_mode")]
-except:
-    pass
-
-# Deactivate
-state["active"] = False
-state["ended_at"] = datetime.datetime.now().isoformat()
-with open(state_file, "w") as f:
-    json.dump(state, f, indent=2)
-
-print("🍳 Cook mode deactivated!")
-print(f"   Task: {task}")
-print(f"   Session started: {started[:19]}")
-print(f"   Messages queued: {queued}")
-
-if cook_items:
-    print("\n   Queued messages:")
-    for i, item in enumerate(cook_items, 1):
-        ts = item.get("timestamp", "?")[:16]
-        print(f"   {i}. [{ts}] {item['text']}")
-    print(f"\n   Process these with: btw  (or btw_read)")
-else:
-    print("   No messages were queued during this session.")
-PYEOF
+  "$_WW_JSON" cook deactivate \
+    --state-file "$COOK_STATE_FILE" \
+    --btw-file "${HOME}/.claude/btw-queue.json"
 }
 
 cook_queue_message() {
@@ -124,43 +51,10 @@ cook_queue_message() {
     return 1
   fi
 
-  python3 << PYEOF
-import json, os, datetime
-
-btw_file = os.path.expanduser("~/.claude/btw-queue.json")
-state_file = os.path.expanduser("~/.claude/state/cook-mode.json")
-
-# Ensure btw file exists
-if not os.path.exists(btw_file):
-    with open(btw_file, "w") as f:
-        json.dump({"items": [], "processed": []}, f)
-
-with open(btw_file) as f:
-    btw = json.load(f)
-
-btw["items"].append({
-    "text": """${message}""",
-    "timestamp": datetime.datetime.now().isoformat(),
-    "processed": False,
-    "cook_mode": True,
-})
-
-with open(btw_file, "w") as f:
-    json.dump(btw, f, indent=2)
-
-# Update cook state counter
-try:
-    with open(state_file) as f:
-        state = json.load(f)
-    state["messages_queued"] = state.get("messages_queued", 0) + 1
-    with open(state_file, "w") as f:
-        json.dump(state, f, indent=2)
-except:
-    pass
-
-count = len([i for i in btw["items"] if not i.get("processed")])
-print(f"📝 Queued ({count} pending)")
-PYEOF
+  "$_WW_JSON" cook queue \
+    --btw-file "${HOME}/.claude/btw-queue.json" \
+    --state-file "$COOK_STATE_FILE" \
+    --message "$message"
 }
 
 cook_check_exit() {
@@ -168,31 +62,7 @@ cook_check_exit() {
   local message_lower
   message_lower=$(echo "$message" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
-  # Check against exit keywords
-  python3 << PYEOF
-import json, os
-
-state_file = os.path.expanduser("~/.claude/state/cook-mode.json")
-msg = """${message_lower}""".strip().lower()
-
-try:
-    with open(state_file) as f:
-        state = json.load(f)
-    keywords = state.get("exit_keywords", ["stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"])
-except:
-    keywords = ["stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"]
-
-# Exact match or starts-with for multi-word keywords
-for kw in keywords:
-    if msg == kw or msg.startswith(kw + " ") or msg.startswith(kw + ",") or msg.startswith(kw + "."):
-        print("exit")
-        exit(0)
-
-# Also check /uncook command
-if msg.strip().startswith("/uncook"):
-    print("exit")
-    exit(0)
-
-print("continue")
-PYEOF
+  "$_WW_JSON" cook check-exit \
+    --state-file "$COOK_STATE_FILE" \
+    --message "$message_lower"
 }

--- a/lib/gitea_updates.py
+++ b/lib/gitea_updates.py
@@ -1,16 +1,16 @@
 """Gitea integration for auto-closing issues and posting progress updates.
 
-Called by the dispatcher when stories complete, fail, or during periodic
+Called by the dispatcher when tasks complete, fail, or during periodic
 status updates.
 
 Usage:
     from lib.gitea_updates import GiteaUpdater
 
     updater = GiteaUpdater("tquick/claude-gate")
-    updater.on_story_started(story)
-    updater.on_story_completed(story)
-    updater.on_story_failed(story, "exit code 1")
-    updater.post_sprint_status(manifest, completed, failed)
+    updater.on_task_started(task)
+    updater.on_task_completed(task)
+    updater.on_task_failed(task, "exit code 1")
+    updater.post_phase_status(manifest, completed, failed)
 """
 
 from __future__ import annotations
@@ -20,63 +20,63 @@ from typing import Optional, TYPE_CHECKING
 from lib.gitea_api import GiteaClient
 
 if TYPE_CHECKING:
-    from lib.manifest import SprintManifest, Story
+    from lib.manifest import PhaseManifest, Task
 
 
 class GiteaUpdater:
-    """Posts updates to Gitea issues as stories progress."""
+    """Posts updates to Gitea issues as tasks progress."""
 
     def __init__(self, repo: str, client: Optional[GiteaClient] = None):
         self.repo = repo
         self.client = client or GiteaClient()
 
-    def on_story_started(self, story: Story) -> None:
-        """Post a comment when an agent starts working on a story."""
-        if not story.issue:
+    def on_task_started(self, task: Task) -> None:
+        """Post a comment when an agent starts working on a task."""
+        if not task.issue:
             return
         self.client.add_comment(
             self.repo,
-            story.issue,
-            f"Agent `{story.agent}` has started working on this issue.",
+            task.issue,
+            f"Agent `{task.agent}` has started working on this issue.",
         )
 
-    def on_story_completed(self, story: Story) -> None:
+    def on_task_completed(self, task: Task) -> None:
         """Close the issue and post a completion comment."""
-        if not story.issue:
+        if not task.issue:
             return
         self.client.add_comment(
             self.repo,
-            story.issue,
-            f"Agent `{story.agent}` has completed this issue.",
+            task.issue,
+            f"Agent `{task.agent}` has completed this issue.",
         )
         self.client.patch(
-            f"repos/{self.repo}/issues/{story.issue}",
+            f"repos/{self.repo}/issues/{task.issue}",
             {"state": "closed"},
         )
 
-    def on_story_failed(self, story: Story, reason: str = "") -> None:
+    def on_task_failed(self, task: Task, reason: str = "") -> None:
         """Post a failure comment (don't close the issue)."""
-        if not story.issue:
+        if not task.issue:
             return
-        msg = f"Agent `{story.agent}` failed on this issue."
+        msg = f"Agent `{task.agent}` failed on this issue."
         if reason:
             msg += f"\n\nReason: {reason}"
-        self.client.add_comment(self.repo, story.issue, msg)
+        self.client.add_comment(self.repo, task.issue, msg)
 
-    def post_sprint_status(
+    def post_phase_status(
         self,
-        manifest: SprintManifest,
+        manifest: PhaseManifest,
         completed: set[str],
         failed: set[str],
     ) -> None:
-        """Post a sprint summary comment to all open issues in the sprint."""
-        total = len(manifest.stories)
+        """Post a phase summary comment to all open issues in the phase."""
+        total = len(manifest.tasks)
         done = len(completed)
         fail = len(failed)
         remaining = total - done - fail
 
         lines = [
-            f"## Sprint Status: {manifest.sprint}",
+            f"## Phase Status: {manifest.phase}",
             f"- Completed: {done}/{total}",
         ]
         if fail:
@@ -84,20 +84,20 @@ class GiteaUpdater:
         if remaining:
             lines.append(f"- Remaining: {remaining}")
 
-        lines.append("\n| Story | Status |")
+        lines.append("\n| Task | Status |")
         lines.append("|-------|--------|")
-        for story in manifest.stories:
-            if story.id in completed:
+        for task in manifest.tasks:
+            if task.id in completed:
                 status = "Done"
-            elif story.id in failed:
+            elif task.id in failed:
                 status = "Failed"
             else:
                 status = "Pending"
-            lines.append(f"| {story.id}: {story.title} | {status} |")
+            lines.append(f"| {task.id}: {task.title} | {status} |")
 
         body = "\n".join(lines)
 
         # Post to each issue that's still open (failed or pending)
-        for story in manifest.stories:
-            if story.issue and story.id not in completed:
-                self.client.add_comment(self.repo, story.issue, body)
+        for task in manifest.tasks:
+            if task.issue and task.id not in completed:
+                self.client.add_comment(self.repo, task.issue, body)

--- a/lib/manifest.py
+++ b/lib/manifest.py
@@ -1,14 +1,14 @@
-"""Sprint manifest parser and data model.
+"""Phase manifest parser and data model.
 
-Defines the YAML format for automated sprint dispatch. The manifest is the
+Defines the YAML format for automated phase dispatch. The manifest is the
 contract between the PM (who plans) and the dispatcher (who executes).
 
 Usage:
-    from lib.manifest import SprintManifest
+    from lib.manifest import PhaseManifest
 
-    manifest = SprintManifest.from_yaml("sprint.yaml")
-    for story in manifest.stories:
-        print(f"{story.id}: {story.title} -> {story.agent}")
+    manifest = PhaseManifest.from_yaml("phase.yaml")
+    for task in manifest.tasks:
+        print(f"{task.id}: {task.title} -> {task.agent}")
 """
 
 from __future__ import annotations
@@ -20,8 +20,8 @@ from typing import Optional
 
 
 @dataclass
-class Story:
-    """A single work item in the sprint."""
+class Task:
+    """A single work item in the phase."""
 
     id: str
     title: str
@@ -36,30 +36,30 @@ class Story:
 
 
 @dataclass
-class SprintManifest:
-    """Complete sprint manifest parsed from YAML."""
+class PhaseManifest:
+    """Complete phase manifest parsed from YAML."""
 
-    sprint: str
+    phase: str
     project: str
     repo: str
-    stories: list[Story]
+    tasks: list[Task]
     worktree_branch: str = ""
     max_parallel: int = 3
 
     @classmethod
-    def from_yaml(cls, path: str | Path) -> SprintManifest:
-        """Parse a sprint manifest from a YAML file."""
+    def from_yaml(cls, path: str | Path) -> PhaseManifest:
+        """Parse a phase manifest from a YAML file."""
         path = Path(path)
         with open(path) as f:
             data = yaml.safe_load(f)
 
-        if not data or "sprint" not in data:
-            raise ValueError(f"Invalid manifest: missing 'sprint' key in {path}")
+        if not data or "phase" not in data:
+            raise ValueError(f"Invalid manifest: missing 'phase' key in {path}")
 
-        stories = []
-        for s in data.get("stories", []):
-            stories.append(
-                Story(
+        tasks = []
+        for s in data.get("tasks", []):
+            tasks.append(
+                Task(
                     id=s["id"],
                     title=s["title"],
                     agent=s["agent"],
@@ -74,10 +74,10 @@ class SprintManifest:
             )
 
         return cls(
-            sprint=data["sprint"],
+            phase=data["phase"],
             project=data.get("project", ""),
             repo=data.get("repo", ""),
-            stories=stories,
+            tasks=tasks,
             worktree_branch=data.get("worktree_branch", ""),
             max_parallel=data.get("max_parallel", 3),
         )
@@ -85,15 +85,15 @@ class SprintManifest:
     def to_yaml(self, path: str | Path) -> None:
         """Write the manifest to a YAML file."""
         data = {
-            "sprint": self.sprint,
+            "phase": self.phase,
             "project": self.project,
             "repo": self.repo,
             "worktree_branch": self.worktree_branch,
             "max_parallel": self.max_parallel,
-            "stories": [],
+            "tasks": [],
         }
-        for s in self.stories:
-            story_data: dict = {
+        for s in self.tasks:
+            task_data: dict = {
                 "id": s.id,
                 "title": s.title,
                 "agent": s.agent,
@@ -102,38 +102,38 @@ class SprintManifest:
                 "prompt": s.prompt,
             }
             if s.depends_on:
-                story_data["depends_on"] = s.depends_on
+                task_data["depends_on"] = s.depends_on
             if s.files:
-                story_data["files"] = s.files
+                task_data["files"] = s.files
             if s.labels:
-                story_data["labels"] = s.labels
+                task_data["labels"] = s.labels
             if s.priority:
-                story_data["priority"] = s.priority
-            data["stories"].append(story_data)
+                task_data["priority"] = s.priority
+            data["tasks"].append(task_data)
 
         path = Path(path)
         with open(path, "w") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
-    def get_story(self, story_id: str) -> Optional[Story]:
-        """Find a story by ID."""
-        for s in self.stories:
-            if s.id == story_id:
+    def get_task(self, task_id: str) -> Optional[Task]:
+        """Find a task by ID."""
+        for s in self.tasks:
+            if s.id == task_id:
                 return s
         return None
 
-    def dependency_order(self) -> list[list[Story]]:
-        """Return stories grouped into dependency layers.
+    def dependency_order(self) -> list[list[Task]]:
+        """Return tasks grouped into dependency layers.
 
-        Each layer contains stories that can run in parallel (all deps satisfied
+        Each layer contains tasks that can run in parallel (all deps satisfied
         by previous layers). This is a topological sort by layers.
         """
         completed: set[str] = set()
-        remaining = {s.id: s for s in self.stories}
-        layers: list[list[Story]] = []
+        remaining = {s.id: s for s in self.tasks}
+        layers: list[list[Task]] = []
 
         while remaining:
-            # Find stories whose deps are all completed
+            # Find tasks whose deps are all completed
             ready = [
                 s for s in remaining.values()
                 if all(d in completed for d in s.depends_on)

--- a/lib/monitor.py
+++ b/lib/monitor.py
@@ -83,7 +83,7 @@ class HealthMonitor:
             exit_code = ap.process.returncode
             if exit_code != 0:
                 issues.append(HealthIssue(
-                    story_id=task_id,
+                    task_id=task_id,
                     agent_name=agent_name,
                     issue_type="process_dead",
                     message=f"Process exited with code {exit_code}",
@@ -95,7 +95,7 @@ class HealthMonitor:
         status_file = os.path.join(STATUS_DIR, f"{agent_name}.json")
         if not os.path.exists(status_file):
             issues.append(HealthIssue(
-                story_id=task_id,
+                task_id=task_id,
                 agent_name=agent_name,
                 issue_type="no_status_file",
                 message="No status file found",
@@ -111,7 +111,7 @@ class HealthMonitor:
                 age_sec = (now - hb_dt).total_seconds()
                 if age_sec > self.stale_threshold:
                     issues.append(HealthIssue(
-                        story_id=task_id,
+                        task_id=task_id,
                         agent_name=agent_name,
                         issue_type="stale_heartbeat",
                         message=f"Heartbeat stale for {int(age_sec)}s (threshold: {self.stale_threshold}s)",

--- a/lib/monitor.py
+++ b/lib/monitor.py
@@ -33,7 +33,7 @@ PROCESS_DEAD_GRACE_SEC = 30  # grace period after process death before flagging
 class HealthIssue:
     """A detected health problem with an agent."""
 
-    story_id: str
+    task_id: str
     agent_name: str
     issue_type: str  # stale_heartbeat | process_dead | no_status_file
     message: str
@@ -59,31 +59,31 @@ class HealthMonitor:
         issues: list[HealthIssue] = []
         now = datetime.datetime.now(datetime.timezone.utc)
 
-        for story_id, ap in self.dispatcher.agents.items():
+        for task_id, ap in self.dispatcher.agents.items():
             if ap.state != "running":
                 continue
 
-            story_issues = self._check_agent(story_id, ap, now)
-            issues.extend(story_issues)
+            task_issues = self._check_agent(task_id, ap, now)
+            issues.extend(task_issues)
 
         return issues
 
     def _check_agent(
         self,
-        story_id: str,
+        task_id: str,
         ap: AgentProcess,
         now: datetime.datetime,
     ) -> list[HealthIssue]:
         """Check a single agent's health."""
         issues: list[HealthIssue] = []
-        agent_name = ap.story.agent
+        agent_name = ap.task.agent
 
         # Check if process is still alive
         if ap.process is not None and ap.process.poll() is not None:
             exit_code = ap.process.returncode
             if exit_code != 0:
                 issues.append(HealthIssue(
-                    story_id=story_id,
+                    story_id=task_id,
                     agent_name=agent_name,
                     issue_type="process_dead",
                     message=f"Process exited with code {exit_code}",
@@ -95,7 +95,7 @@ class HealthMonitor:
         status_file = os.path.join(STATUS_DIR, f"{agent_name}.json")
         if not os.path.exists(status_file):
             issues.append(HealthIssue(
-                story_id=story_id,
+                story_id=task_id,
                 agent_name=agent_name,
                 issue_type="no_status_file",
                 message="No status file found",
@@ -111,7 +111,7 @@ class HealthMonitor:
                 age_sec = (now - hb_dt).total_seconds()
                 if age_sec > self.stale_threshold:
                     issues.append(HealthIssue(
-                        story_id=story_id,
+                        story_id=task_id,
                         agent_name=agent_name,
                         issue_type="stale_heartbeat",
                         message=f"Heartbeat stale for {int(age_sec)}s (threshold: {self.stale_threshold}s)",
@@ -125,24 +125,24 @@ class HealthMonitor:
 
         Returns True if recovery was attempted.
         """
-        story_id = issue.story_id
-        retry_count = self.retry_counts.get(story_id, 0)
+        task_id = issue.task_id
+        retry_count = self.retry_counts.get(task_id, 0)
 
         if retry_count >= self.max_retries:
-            print(f"[monitor] {story_id}: max retries ({self.max_retries}) exceeded, marking failed")
-            ap = self.dispatcher.agents.get(story_id)
+            print(f"[monitor] {task_id}: max retries ({self.max_retries}) exceeded, marking failed")
+            ap = self.dispatcher.agents.get(task_id)
             if ap:
                 ap.state = "failed"
-                self.dispatcher.failed.add(story_id)
+                self.dispatcher.failed.add(task_id)
             return False
 
         if issue.issue_type == "process_dead":
-            print(f"[monitor] {story_id}: restarting (attempt {retry_count + 1}/{self.max_retries})")
-            ap = self.dispatcher.agents.get(story_id)
+            print(f"[monitor] {task_id}: restarting (attempt {retry_count + 1}/{self.max_retries})")
+            ap = self.dispatcher.agents.get(task_id)
             if ap:
-                new_ap = self.dispatcher._spawn_agent(ap.story)
-                self.dispatcher.agents[story_id] = new_ap
-                self.retry_counts[story_id] = retry_count + 1
+                new_ap = self.dispatcher._spawn_agent(ap.task)
+                self.dispatcher.agents[task_id] = new_ap
+                self.retry_counts[task_id] = retry_count + 1
                 return True
 
         return False
@@ -156,4 +156,4 @@ def print_health_report(issues: list[HealthIssue]) -> None:
     print(f"[monitor] {len(issues)} health issue(s):")
     for issue in issues:
         icon = "!!" if issue.severity == "critical" else "  "
-        print(f"  {icon} {issue.story_id} ({issue.agent_name}): {issue.issue_type} — {issue.message}")
+        print(f"  {icon} {issue.task_id} ({issue.agent_name}): {issue.issue_type} — {issue.message}")

--- a/scoreboard.md
+++ b/scoreboard.md
@@ -1,0 +1,20 @@
+# Phase Scoreboard: multi-agent-smoke-test
+_Updated: 2026-03-10 13:58:41_
+
+**Total:** 3 tasks | **Done:** 3 | **Failed:** 0 | **Running:** 0 | **Pending:** 0
+
+## Agent Leaderboard
+
+| Agent | Done | Running | Failed | Pending |
+|-------|------|---------|--------|---------|
+| agent-alpha | 1 | 0 | 0 | 0 |
+| agent-beta | 1 | 0 | 0 | 0 |
+| agent-gamma | 1 | 0 | 0 | 0 |
+
+## Tasks
+
+| Task | Repo | Agent | Status |
+|-------|------|-------|--------|
+| multi#1: Parallel agent A | wasteland-orchestrator | agent-alpha | Done |
+| multi#2: Parallel agent B | wasteland-orchestrator | agent-beta | Done |
+| multi#3: Sequential agent C (depends on A and B) | wasteland-orchestrator | agent-gamma | Done |

--- a/skills/agent-protocol/SKILL.md
+++ b/skills/agent-protocol/SKILL.md
@@ -82,7 +82,7 @@ gitea_create_issue "tquick/meeting-scribe" "Issue title" "Issue body" "1,2,3"
 All dev work MUST happen in worktrees:
 
 ```bash
-# Create worktree for a story
+# Create worktree for a task
 git worktree add ../.worktrees/issue-17-assistant-skeleton -b feat/issue-17-assistant-skeleton
 
 # Work in the worktree
@@ -106,7 +106,7 @@ source ~/.claude/lib/agent-tx.sh
 ### Usage
 ```bash
 # Start a transaction — state your intent and justify it
-tx_begin "Implementing rolling summary" "Sprint 1 story #18" "tquick/meeting-scribe" 18
+tx_begin "Implementing rolling summary" "Phase 1 task #18" "tquick/meeting-scribe" 18
 
 # Log each significant action with what + why
 tx_action "Created src/summary_prompt.py" "Prompt template for condensed meeting minutes"
@@ -124,7 +124,7 @@ tx_end "success" "Rolling summary working, broadcasts every 2 minutes"
 
 ### What Makes a Good Transaction
 - **Intent**: Human-readable, high-level ("Implementing rolling summary" not "editing files")
-- **Justification**: Why this is being done now ("Sprint 1 story #18")
+- **Justification**: Why this is being done now ("Phase 1 task #18")
 - **Actions**: Describe what changed and why, not tool-level details
   - Good: `tx_action "Added Ollama health check" "Startup should fail gracefully if Ollama is down"`
   - Bad: `tx_action "Edited main.py line 42" "Changed code"`

--- a/swarm.py
+++ b/swarm.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """Swarm dispatcher — the brain of the orchestrator.
 
-Reads a sprint manifest, builds a dependency DAG, spawns `claude -p` agents
+Reads a phase manifest, builds a dependency DAG, spawns `claude -p` agents
 in worktrees, and monitors their progress via status files.
 
 Usage:
-    python3 swarm.py sprint.yaml                # Launch the swarm
-    python3 swarm.py sprint.yaml --dry-run      # Show execution plan
+    python3 swarm.py phase.yaml                # Launch the swarm
+    python3 swarm.py phase.yaml --dry-run      # Show execution plan
     python3 swarm.py --status                   # Show running agents
 """
 
@@ -25,7 +25,7 @@ from typing import Optional
 
 from lib.agent_status import AgentStatus, list_agents
 from lib.conflict import detect_conflicts, apply_serialization, print_conflicts
-from lib.manifest import SprintManifest, Story
+from lib.manifest import PhaseManifest, Task
 from lib.gitea_updates import GiteaUpdater
 from lib.monitor import HealthMonitor, print_health_report
 
@@ -50,7 +50,7 @@ REPO_PATHS: dict[str, str] = {
 class AgentProcess:
     """Tracks a running claude -p agent."""
 
-    story: Story
+    task: Task
     process: Optional[subprocess.Popen] = None
     pid: Optional[int] = None
     state: str = "pending"  # pending | running | done | failed
@@ -59,9 +59,9 @@ class AgentProcess:
 
 
 class Dispatcher:
-    """Spawns and manages agent processes from a sprint manifest."""
+    """Spawns and manages agent processes from a phase manifest."""
 
-    def __init__(self, manifest: SprintManifest, dry_run: bool = False):
+    def __init__(self, manifest: PhaseManifest, dry_run: bool = False):
         self.manifest = manifest
         self.dry_run = dry_run
         self.agents: dict[str, AgentProcess] = {}
@@ -71,7 +71,7 @@ class Dispatcher:
 
         # Multi-repo: create per-repo updaters
         self._gitea_updaters: dict[str, GiteaUpdater] = {}
-        repos = set(s.repo for s in manifest.stories if s.repo)
+        repos = set(s.repo for s in manifest.tasks if s.repo)
         for repo in repos:
             self._gitea_updaters[repo] = GiteaUpdater(repo)
         # Legacy single-repo fallback
@@ -89,36 +89,36 @@ class Dispatcher:
 
     def _kill_all(self) -> None:
         """Terminate all running agent processes."""
-        for story_id, ap in self.agents.items():
+        for task_id, ap in self.agents.items():
             if ap.process and ap.process.poll() is None:
-                print(f"[swarm] Terminating {story_id} (PID {ap.pid})")
+                print(f"[swarm] Terminating {task_id} (PID {ap.pid})")
                 ap.process.terminate()
                 try:
                     ap.process.wait(timeout=5)
                 except subprocess.TimeoutExpired:
                     ap.process.kill()
 
-    def _resolve_repo_path(self, story: Story) -> str:
-        """Resolve the local filesystem path for a story's repository."""
-        return REPO_PATHS.get(story.repo, os.path.expanduser(f"~/projects/{story.repo.split('/')[-1]}"))
+    def _resolve_repo_path(self, task: Task) -> str:
+        """Resolve the local filesystem path for a task's repository."""
+        return REPO_PATHS.get(task.repo, os.path.expanduser(f"~/projects/{task.repo.split('/')[-1]}"))
 
-    def _build_prompt(self, story: Story) -> str:
+    def _build_prompt(self, task: Task) -> str:
         """Build the prompt for a claude -p agent with worktree and PR instructions."""
-        repo_path = self._resolve_repo_path(story)
-        branch_name = f"feat/issue-{story.issue}-{story.title.lower()[:30].replace(' ', '-').rstrip('-')}"
+        repo_path = self._resolve_repo_path(task)
+        branch_name = f"feat/issue-{task.issue}-{task.title.lower()[:30].replace(' ', '-').rstrip('-')}"
         worktree_dir = f"{repo_path}/.worktrees/{branch_name}"
 
         parts = [
-            f"You are agent '{story.agent}' working on: {story.title}",
-            f"Repository: {story.repo}",
+            f"You are agent '{task.agent}' working on: {task.title}",
+            f"Repository: {task.repo}",
             f"Local repo path: {repo_path}",
         ]
-        if story.issue:
-            parts.append(f"Gitea issue: #{story.issue}")
-        if story.files:
-            parts.append(f"Key files: {', '.join(story.files)}")
-        if story.prompt:
-            parts.append(f"\nTask details:\n{story.prompt}")
+        if task.issue:
+            parts.append(f"Gitea issue: #{task.issue}")
+        if task.files:
+            parts.append(f"Key files: {', '.join(task.files)}")
+        if task.prompt:
+            parts.append(f"\nTask details:\n{task.prompt}")
 
         parts.append(f"""
 
@@ -145,16 +145,16 @@ Update or create CHANGELOG.md in Keep a Changelog format. Add your changes under
 git add -A
 git commit -m "feat: <description>
 
-Closes #{story.issue}
+Closes #{task.issue}
 
-Co-Authored-By: {story.agent} <{story.agent}@wasteland.dev>"
+Co-Authored-By: {task.agent} <{task.agent}@wasteland.dev>"
 git push -u origin {branch_name}
 ```
 
 ### 5. Create Pull Request
 Create a PR using gh or the Gitea API. The PR title should reference the issue.
 ```bash
-gh pr create --repo {story.repo} --title "feat: {story.title}" --body "Closes #{story.issue}
+gh pr create --repo {task.repo} --title "feat: {task.title}" --body "Closes #{task.issue}
 
 ## Summary
 <describe changes>
@@ -162,19 +162,19 @@ gh pr create --repo {story.repo} --title "feat: {story.title}" --body "Closes #{
 ## Test Plan
 <how to verify>
 
-Agent: {story.agent} | Sprint: {self.manifest.sprint}"
+Agent: {task.agent} | Phase: {self.manifest.phase}"
 ```
 If gh doesn't work with Gitea, use curl with the Gitea API:
 ```bash
 source ~/.claude/lib/gitea-api.sh
-gitea_post "repos/{story.repo}/pulls" '{{"title":"feat: {story.title}","head":"{branch_name}","base":"main","body":"Closes #{story.issue}\\n\\nAgent: {story.agent}"}}'
+gitea_post "repos/{task.repo}/pulls" '{{"title":"feat: {task.title}","head":"{branch_name}","base":"main","body":"Closes #{task.issue}\\n\\nAgent: {task.agent}"}}'
 ```
 
 ### 6. Request Review
 After creating the PR, add a comment mentioning @claude for automated review:
 ```bash
 # If the repo has claude-review action, it triggers on @claude mention
-gitea_post "repos/{story.repo}/issues/<PR_NUMBER>/comments" '{{"body":"@claude please review this PR"}}'
+gitea_post "repos/{task.repo}/issues/<PR_NUMBER>/comments" '{{"body":"@claude please review this PR"}}'
 ```
 
 ### 7. Agent Protocol
@@ -182,49 +182,49 @@ gitea_post "repos/{story.repo}/issues/<PR_NUMBER>/comments" '{{"body":"@claude p
 source ~/.claude/lib/agent-status.sh
 source ~/.claude/lib/gitea-api.sh
 source ~/.claude/lib/agent-tx.sh
-export CLAUDE_AGENT_NAME={story.agent}
-agent_status_update "working" "{story.title}" "{story.repo}" {story.issue or 0}
-tx_begin "{story.title}" "Sprint: {self.manifest.sprint}, Issue #{story.issue}" "{story.repo}" {story.issue or 0}
+export CLAUDE_AGENT_NAME={task.agent}
+agent_status_update "working" "{task.title}" "{task.repo}" {task.issue or 0}
+tx_begin "{task.title}" "Phase: {self.manifest.phase}, Issue #{task.issue}" "{task.repo}" {task.issue or 0}
 ```
 When done:
 ```bash
 tx_end "success" "Brief summary of what was done"
-agent_status_update "idle" "Completed {story.id}"
+agent_status_update "idle" "Completed {task.id}"
 ```
 """)
         return "\n".join(parts)
 
-    def _get_updater(self, story: Story) -> Optional[GiteaUpdater]:
-        """Get the Gitea updater for a story's repo."""
-        return self._gitea_updaters.get(story.repo) or self.gitea
+    def _get_updater(self, task: Task) -> Optional[GiteaUpdater]:
+        """Get the Gitea updater for a task's repo."""
+        return self._gitea_updaters.get(task.repo) or self.gitea
 
-    def _spawn_agent(self, story: Story) -> AgentProcess:
-        """Spawn a single claude -p agent in the story's repo directory."""
-        prompt = self._build_prompt(story)
+    def _spawn_agent(self, task: Task) -> AgentProcess:
+        """Spawn a single claude -p agent in the task's repo directory."""
+        prompt = self._build_prompt(task)
         output_dir = Path("logs")
         output_dir.mkdir(exist_ok=True)
-        output_file = str(output_dir / f"{story.id.replace('#', '')}-{story.agent}.log")
+        output_file = str(output_dir / f"{task.id.replace('#', '')}-{task.agent}.log")
 
-        repo_path = self._resolve_repo_path(story)
+        repo_path = self._resolve_repo_path(task)
         cmd = [
             CLAUDE_BIN, "-p", prompt,
             "--output-format", "text",
             "--dangerously-skip-permissions",
         ]
 
-        print(f"[swarm] Spawning {story.agent} for {story.id}: {story.title}")
-        print(f"[swarm]   repo: {story.repo} -> {repo_path}")
+        print(f"[swarm] Spawning {task.agent} for {task.id}: {task.title}")
+        print(f"[swarm]   repo: {task.repo} -> {repo_path}")
 
-        updater = self._get_updater(story)
+        updater = self._get_updater(task)
         if updater and not self.dry_run:
             try:
-                updater.on_story_started(story)
+                updater.on_task_started(task)
             except Exception as e:
                 print(f"[swarm] Warning: Gitea update failed: {e}")
 
         if self.dry_run:
             print(f"[swarm]   DRY RUN: would run: claude -p '<prompt>' > {output_file}")
-            return AgentProcess(story=story, state="done")
+            return AgentProcess(task=task, state="done")
 
         # Strip CLAUDECODE env var so nested claude -p sessions can launch
         # Ensure node is on PATH (nvm may not be sourced in subprocess)
@@ -251,7 +251,7 @@ agent_status_update "idle" "Completed {story.id}"
             )
 
         ap = AgentProcess(
-            story=story,
+            task=task,
             process=proc,
             pid=proc.pid,
             state="running",
@@ -263,32 +263,32 @@ agent_status_update "idle" "Completed {story.id}"
 
         return ap
 
-    def _check_agent(self, story_id: str) -> None:
+    def _check_agent(self, task_id: str) -> None:
         """Check if an agent process has completed."""
-        ap = self.agents[story_id]
+        ap = self.agents[task_id]
         if ap.state != "running" or ap.process is None:
             return
 
         ret = ap.process.poll()
         if ret is not None:
             ap.exit_code = ret
-            updater = self._get_updater(ap.story)
+            updater = self._get_updater(ap.task)
             if ret == 0:
                 ap.state = "done"
-                self.completed.add(story_id)
-                print(f"[swarm] {story_id} completed successfully")
+                self.completed.add(task_id)
+                print(f"[swarm] {task_id} completed successfully")
                 if updater:
                     try:
-                        updater.on_story_completed(ap.story)
+                        updater.on_task_completed(ap.task)
                     except Exception as e:
                         print(f"[swarm] Warning: Gitea close failed: {e}")
             else:
                 ap.state = "failed"
-                self.failed.add(story_id)
-                print(f"[swarm] {story_id} FAILED (exit code {ret})")
+                self.failed.add(task_id)
+                print(f"[swarm] {task_id} FAILED (exit code {ret})")
                 if updater:
                     try:
-                        updater.on_story_failed(ap.story, f"exit code {ret}")
+                        updater.on_task_failed(ap.task, f"exit code {ret}")
                     except Exception as e:
                         print(f"[swarm] Warning: Gitea update failed: {e}")
             self._update_scoreboard()
@@ -298,33 +298,33 @@ agent_status_update "idle" "Completed {story.id}"
         from datetime import datetime
 
         lines = [
-            f"# Sprint Scoreboard: {self.manifest.sprint}",
+            f"# Phase Scoreboard: {self.manifest.phase}",
             f"_Updated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}_\n",
-            f"**Total:** {len(self.manifest.stories)} stories | "
+            f"**Total:** {len(self.manifest.tasks)} tasks | "
             f"**Done:** {len(self.completed)} | "
             f"**Failed:** {len(self.failed)} | "
             f"**Running:** {self._running_count()} | "
-            f"**Pending:** {len(self.manifest.stories) - len(self.completed) - len(self.failed) - self._running_count()}\n",
+            f"**Pending:** {len(self.manifest.tasks) - len(self.completed) - len(self.failed) - self._running_count()}\n",
         ]
 
         # Agent leaderboard
         agent_stats: dict[str, dict] = {}
-        for story in self.manifest.stories:
-            if story.agent not in agent_stats:
-                agent_stats[story.agent] = {"done": 0, "failed": 0, "running": 0, "pending": 0, "stories": []}
+        for task in self.manifest.tasks:
+            if task.agent not in agent_stats:
+                agent_stats[task.agent] = {"done": 0, "failed": 0, "running": 0, "pending": 0, "tasks": []}
             state = "pending"
-            if story.id in self.completed:
+            if task.id in self.completed:
                 state = "done"
-                agent_stats[story.agent]["done"] += 1
-            elif story.id in self.failed:
+                agent_stats[task.agent]["done"] += 1
+            elif task.id in self.failed:
                 state = "failed"
-                agent_stats[story.agent]["failed"] += 1
-            elif story.id in self.agents and self.agents[story.id].state == "running":
+                agent_stats[task.agent]["failed"] += 1
+            elif task.id in self.agents and self.agents[task.id].state == "running":
                 state = "running"
-                agent_stats[story.agent]["running"] += 1
+                agent_stats[task.agent]["running"] += 1
             else:
-                agent_stats[story.agent]["pending"] += 1
-            agent_stats[story.agent]["stories"].append((story, state))
+                agent_stats[task.agent]["pending"] += 1
+            agent_stats[task.agent]["tasks"].append((task, state))
 
         lines.append("## Agent Leaderboard\n")
         lines.append("| Agent | Done | Running | Failed | Pending |")
@@ -332,35 +332,35 @@ agent_status_update "idle" "Completed {story.id}"
         for agent, stats in sorted(agent_stats.items(), key=lambda x: -x[1]["done"]):
             lines.append(f"| {agent} | {stats['done']} | {stats['running']} | {stats['failed']} | {stats['pending']} |")
 
-        lines.append("\n## Stories\n")
-        lines.append("| Story | Repo | Agent | Status |")
+        lines.append("\n## Tasks\n")
+        lines.append("| Task | Repo | Agent | Status |")
         lines.append("|-------|------|-------|--------|")
-        for story in self.manifest.stories:
-            if story.id in self.completed:
+        for task in self.manifest.tasks:
+            if task.id in self.completed:
                 status = "Done"
-            elif story.id in self.failed:
+            elif task.id in self.failed:
                 status = "FAILED"
-            elif story.id in self.agents and self.agents[story.id].state == "running":
+            elif task.id in self.agents and self.agents[task.id].state == "running":
                 status = "Running..."
             else:
                 status = "Pending"
-            repo_short = story.repo.split("/")[-1] if story.repo else ""
-            lines.append(f"| {story.id}: {story.title[:50]} | {repo_short} | {story.agent} | {status} |")
+            repo_short = task.repo.split("/")[-1] if task.repo else ""
+            lines.append(f"| {task.id}: {task.title[:50]} | {repo_short} | {task.agent} | {status} |")
 
         Path(SCOREBOARD_FILE).write_text("\n".join(lines) + "\n")
 
-    def _ready_stories(self) -> list[Story]:
-        """Find stories whose dependencies are met and haven't started."""
+    def _ready_tasks(self) -> list[Task]:
+        """Find tasks whose dependencies are met and haven't started."""
         started = set(self.agents.keys())
         ready = []
-        for story in self.manifest.stories:
-            if story.id in started:
+        for task in self.manifest.tasks:
+            if task.id in started:
                 continue
-            if story.id in self.failed:
+            if task.id in self.failed:
                 continue
             # Check all deps are completed
-            if all(d in self.completed for d in story.depends_on):
-                ready.append(story)
+            if all(d in self.completed for d in task.depends_on):
+                ready.append(task)
         return ready
 
     def _running_count(self) -> int:
@@ -368,12 +368,12 @@ agent_status_update "idle" "Completed {story.id}"
         return sum(1 for ap in self.agents.values() if ap.state == "running")
 
     def run(self) -> bool:
-        """Execute the full sprint dispatch loop.
+        """Execute the full phase dispatch loop.
 
-        Returns True if all stories completed successfully.
+        Returns True if all tasks completed successfully.
         """
-        print(f"[swarm] Starting sprint: {self.manifest.sprint}")
-        print(f"[swarm] {len(self.manifest.stories)} stories, max {self.manifest.max_parallel} parallel")
+        print(f"[swarm] Starting phase: {self.manifest.phase}")
+        print(f"[swarm] {len(self.manifest.tasks)} tasks, max {self.manifest.max_parallel} parallel")
 
         # Detect and resolve file ownership conflicts
         conflicts = detect_conflicts(self.manifest)
@@ -391,10 +391,10 @@ agent_status_update "idle" "Completed {story.id}"
                     print(f"  {s.id}: {s.title} -> {s.agent}{deps}")
             print("\n[swarm] === End Plan ===")
             # Still spawn in dry-run to show what would happen
-            for story in self.manifest.stories:
-                ap = self._spawn_agent(story)
-                self.agents[story.id] = ap
-                self.completed.add(story.id)
+            for task in self.manifest.tasks:
+                ap = self._spawn_agent(task)
+                self.agents[task.id] = ap
+                self.completed.add(task.id)
             return True
 
         health_monitor = HealthMonitor(self)
@@ -402,8 +402,8 @@ agent_status_update "idle" "Completed {story.id}"
 
         while not self._shutdown:
             # Check running agents
-            for story_id in list(self.agents.keys()):
-                self._check_agent(story_id)
+            for task_id in list(self.agents.keys()):
+                self._check_agent(task_id)
 
             # Periodic health monitoring (every 3rd poll)
             health_check_counter += 1
@@ -416,43 +416,43 @@ agent_status_update "idle" "Completed {story.id}"
                             health_monitor.attempt_recovery(issue)
 
             # Check if we're done
-            total = len(self.manifest.stories)
+            total = len(self.manifest.tasks)
             done = len(self.completed) + len(self.failed)
             if done >= total:
                 break
 
-            # Spawn ready stories up to max_parallel
-            ready = self._ready_stories()
+            # Spawn ready tasks up to max_parallel
+            ready = self._ready_tasks()
             running = self._running_count()
             slots = self.manifest.max_parallel - running
 
-            for story in ready[:slots]:
-                ap = self._spawn_agent(story)
-                self.agents[story.id] = ap
+            for task in ready[:slots]:
+                ap = self._spawn_agent(task)
+                self.agents[task.id] = ap
 
             time.sleep(POLL_INTERVAL)
 
         # Final summary
-        print(f"\n[swarm] === Sprint Summary ===")
-        print(f"  Completed: {len(self.completed)}/{len(self.manifest.stories)}")
+        print(f"\n[swarm] === Phase Summary ===")
+        print(f"  Completed: {len(self.completed)}/{len(self.manifest.tasks)}")
         if self.failed:
             print(f"  Failed: {', '.join(self.failed)}")
-        for story_id, ap in self.agents.items():
+        for task_id, ap in self.agents.items():
             status = "OK" if ap.state == "done" else ap.state.upper()
-            print(f"  {story_id}: {ap.story.title} [{status}]")
+            print(f"  {task_id}: {ap.task.title} [{status}]")
 
         # Final scoreboard
         self._update_scoreboard()
         print(f"  Scoreboard: {SCOREBOARD_FILE}")
 
-        # Post final sprint status to Gitea (per-repo)
+        # Post final phase status to Gitea (per-repo)
         if not self.dry_run:
             for repo, updater in self._gitea_updaters.items():
                 try:
-                    # Filter manifest to this repo's stories for the status post
-                    updater.post_sprint_status(self.manifest, self.completed, self.failed)
+                    # Filter manifest to this repo's tasks for the status post
+                    updater.post_phase_status(self.manifest, self.completed, self.failed)
                 except Exception as e:
-                    print(f"[swarm] Warning: Gitea sprint status for {repo} failed: {e}")
+                    print(f"[swarm] Warning: Gitea phase status for {repo} failed: {e}")
 
         return len(self.failed) == 0 and not self._shutdown
 
@@ -472,8 +472,8 @@ def show_status() -> None:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Swarm dispatcher for sprint execution")
-    parser.add_argument("manifest", nargs="?", help="Path to sprint.yaml manifest")
+    parser = argparse.ArgumentParser(description="Swarm dispatcher for phase execution")
+    parser.add_argument("manifest", nargs="?", help="Path to phase.yaml manifest")
     parser.add_argument("--status", action="store_true", help="Show current agent statuses")
     parser.add_argument("--dry-run", action="store_true", help="Show execution plan without spawning")
 
@@ -486,7 +486,7 @@ def main():
     if not args.manifest:
         parser.error("manifest file required (or use --status)")
 
-    manifest = SprintManifest.from_yaml(args.manifest)
+    manifest = PhaseManifest.from_yaml(args.manifest)
     dispatcher = Dispatcher(manifest, dry_run=args.dry_run)
     success = dispatcher.run()
     sys.exit(0 if success else 1)

--- a/tools/bin/ww-json-tool.py
+++ b/tools/bin/ww-json-tool.py
@@ -1,0 +1,1304 @@
+#!/usr/bin/env python3
+"""ww-json-tool — CLI for WastelandWares JSON ops.
+
+Replaces all inline python3 -c "..." blocks in shell scripts.
+Each subcommand handles a specific JSON operation pattern.
+
+Usage:
+    ww-json-tool.py json safe-string "hello world"
+    ww-json-tool.py status write --agent pm --state working --task "doing stuff" --pid 1234 --file /tmp/s.json
+    ww-json-tool.py tx begin --id tx_123 --agent pm --intent "test" --justification "test" --file /tmp/tx.json
+"""
+
+import argparse
+import datetime
+import glob as glob_mod
+import json
+import os
+import subprocess
+import sys
+import uuid
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+def _now_iso():
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _now_local_iso():
+    return datetime.datetime.now().isoformat()
+
+
+def _read_json(path, default=None):
+    try:
+        with open(os.path.expanduser(path)) as f:
+            return json.load(f)
+    except Exception:
+        return default if default is not None else {}
+
+
+def _write_json(path, data):
+    path = os.path.expanduser(path)
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+    f.close()
+
+
+# ── json subcommands ────────────────────────────────────────────────────
+
+def cmd_json_safe_string(args):
+    """Output a JSON-escaped string."""
+    print(json.dumps(args.value))
+
+
+def cmd_json_get(args):
+    """Read a key from a JSON file."""
+    data = _read_json(args.file)
+    val = data.get(args.key, args.default)
+    if val is None:
+        print("")
+    elif isinstance(val, (dict, list)):
+        print(json.dumps(val))
+    else:
+        print(val)
+
+
+def cmd_json_set(args):
+    """Set a key in a JSON file."""
+    data = _read_json(args.file, {})
+    try:
+        data[args.key] = json.loads(args.value)
+    except (json.JSONDecodeError, ValueError):
+        data[args.key] = args.value
+    _write_json(args.file, data)
+
+
+def cmd_json_stdin_key(args):
+    """Read a key from JSON on stdin."""
+    try:
+        data = json.load(sys.stdin)
+        val = data.get(args.key, args.default or "")
+        if isinstance(val, (dict, list)):
+            print(json.dumps(val))
+        else:
+            print(val if val is not None else "")
+    except Exception:
+        print(args.default or "")
+
+
+def cmd_json_array_length(args):
+    """Read a JSON array from stdin and print its length."""
+    try:
+        data = json.load(sys.stdin)
+        if isinstance(data, list):
+            print(len(data))
+        else:
+            print(args.default)
+    except Exception:
+        print(args.default)
+
+
+def cmd_json_build_object(args):
+    """Build a JSON object from key=value pairs."""
+    obj = {}
+    for pair in args.pairs:
+        if "=" not in pair:
+            continue
+        key, val = pair.split("=", 1)
+        if val in ("null", "None"):
+            obj[key] = None
+        elif val == "true":
+            obj[key] = True
+        elif val == "false":
+            obj[key] = False
+        else:
+            try:
+                obj[key] = int(val)
+            except ValueError:
+                try:
+                    obj[key] = float(val)
+                except ValueError:
+                    obj[key] = val
+    if args.file:
+        _write_json(args.file, obj)
+    else:
+        print(json.dumps(obj, indent=2))
+
+
+# ── status subcommands ──────────────────────────────────────────────────
+
+def cmd_status_write(args):
+    """Write a complete agent status JSON file."""
+    avatar = {}
+    fpath = os.path.expanduser(args.file)
+    if os.path.exists(fpath):
+        existing = _read_json(fpath)
+        avatar = existing.get("avatar", {})
+
+    issue = None
+    if args.issue and args.issue not in ("", "null", "None"):
+        try:
+            issue = int(args.issue)
+        except ValueError:
+            issue = args.issue
+
+    now = _now_iso()
+    status = {
+        "agent": args.agent,
+        "state": args.state,
+        "task": args.task,
+        "repo": args.repo if args.repo else None,
+        "issue": issue,
+        "started_at": now,
+        "last_heartbeat": now,
+        "pid": args.pid,
+        "avatar": avatar,
+    }
+    _write_json(fpath, status)
+
+
+def cmd_status_heartbeat(args):
+    """Update heartbeat timestamp and pid in existing status file."""
+    data = _read_json(args.file)
+    if not data:
+        return
+    data["last_heartbeat"] = args.timestamp or _now_iso()
+    data["pid"] = args.pid
+    _write_json(args.file, data)
+
+
+def cmd_status_set_avatar(args):
+    """Update avatar field in existing status file."""
+    data = _read_json(args.file)
+    if not data:
+        return
+    try:
+        data["avatar"] = json.loads(args.avatar_json)
+    except json.JSONDecodeError:
+        data["avatar"] = {}
+    _write_json(args.file, data)
+
+
+def cmd_status_list(args):
+    """List all agent statuses with staleness and process-alive checks."""
+    status_dir = os.path.expanduser(args.dir)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    agents = []
+
+    for f in glob_mod.glob(os.path.join(status_dir, "*.json")):
+        try:
+            with open(f) as fh:
+                data = json.load(fh)
+            hb = data.get("last_heartbeat", "")
+            if hb:
+                hb_dt = datetime.datetime.fromisoformat(hb.replace("Z", "+00:00"))
+                stale_sec = (now - hb_dt).total_seconds()
+                data["stale"] = stale_sec > 300
+                data["heartbeat_age_sec"] = int(stale_sec)
+            pid = data.get("pid")
+            if pid:
+                try:
+                    os.kill(pid, 0)
+                    data["process_alive"] = True
+                except (OSError, ProcessLookupError):
+                    data["process_alive"] = False
+            agents.append(data)
+        except Exception:
+            pass
+
+    print(json.dumps(agents, indent=2))
+
+
+def cmd_status_list_human(args):
+    """List agent statuses in human-readable format (for ww_agents)."""
+    status_dir = os.path.expanduser(args.dir)
+    files = sorted(glob_mod.glob(os.path.join(status_dir, "*.json")))
+    if not files:
+        print("No active agents")
+        return
+    for f in files:
+        try:
+            with open(f) as fh:
+                d = json.load(fh)
+            name = os.path.basename(f).replace(".json", "")
+            state = d.get("state", "?")
+            msg = d.get("message", "") or d.get("task", "")
+            icons = {"working": "\u2692", "idle": "\u23f8", "done": "\u2714", "error": "\u2718"}
+            icon = icons.get(state, "\u2753")
+            print(f"  {icon} {name:20s} {state:10s} {msg}")
+        except Exception:
+            pass
+
+
+# ── tx subcommands ──────────────────────────────────────────────────────
+
+def cmd_tx_begin(args):
+    """Create a new transaction JSON file."""
+    issue = None
+    if args.issue and args.issue not in ("", "null", "None"):
+        try:
+            issue = int(args.issue)
+        except ValueError:
+            issue = args.issue
+
+    tx = {
+        "id": args.id,
+        "agent": args.agent,
+        "intent": args.intent,
+        "justification": args.justification,
+        "repo": args.repo if args.repo else None,
+        "issue": issue,
+        "state": "active",
+        "started_at": args.timestamp or _now_iso(),
+        "actions": [],
+    }
+    _write_json(args.file, tx)
+    print(args.id)
+
+
+def cmd_tx_action(args):
+    """Append an action to an existing transaction."""
+    data = _read_json(args.file)
+    if not data:
+        print("WARNING: No active transaction file.", file=sys.stderr)
+        sys.exit(1)
+    data.setdefault("actions", []).append({
+        "timestamp": args.timestamp,
+        "what": args.what,
+        "why": args.why,
+    })
+    _write_json(args.file, data)
+
+
+def cmd_tx_end(args):
+    """Complete a transaction, archive to log dir."""
+    data = _read_json(args.file)
+    if not data:
+        print("WARNING: No active transaction to end.", file=sys.stderr)
+        sys.exit(1)
+
+    data["state"] = "completed"
+    data["outcome"] = args.outcome
+    data["summary"] = args.summary if args.summary else None
+    data["ended_at"] = args.timestamp
+    data["action_count"] = len(data.get("actions", []))
+
+    log_dir = os.path.expanduser(args.log_dir)
+    os.makedirs(log_dir, exist_ok=True)
+    log_path = os.path.join(log_dir, data["id"] + ".json")
+    _write_json(log_path, data)
+
+    print(f'Transaction {data["id"]} completed: {data["outcome"]} ({data["action_count"]} actions)')
+
+
+def cmd_tx_recent(args):
+    """List recent transactions from log dir."""
+    log_dir = os.path.expanduser(args.log_dir)
+    tx_dir = os.path.expanduser(args.tx_dir)
+    files = sorted(glob_mod.glob(os.path.join(log_dir, "*.json")), reverse=True)[:args.count]
+
+    txs = []
+    for f in files:
+        try:
+            with open(f) as fh:
+                txs.append(json.load(fh))
+        except Exception:
+            pass
+
+    for f in glob_mod.glob(os.path.join(tx_dir, "*.current.json")):
+        try:
+            with open(f) as fh:
+                txs.insert(0, json.load(fh))
+        except Exception:
+            pass
+
+    print(json.dumps(txs, indent=2))
+
+
+# ── cook subcommands ────────────────────────────────────────────────────
+
+def cmd_cook_read(args):
+    """Read cook mode state, output yes/no."""
+    data = _read_json(args.file, {"active": False})
+    print("yes" if data.get("active", False) else "no")
+
+
+def cmd_cook_activate(args):
+    """Write cook state as active."""
+    state = {
+        "active": True,
+        "started_at": _now_local_iso(),
+        "task": args.task,
+        "messages_queued": 0,
+        "exit_keywords": ["stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"],
+    }
+    _write_json(args.file, state)
+    print("\U0001f525 LET HIM COOK \u2014 Cook mode activated!")
+    print(f"   Task: {state['task']}")
+    print(f"   Started: {state['started_at'][:19]}")
+    print("   User messages will be queued as btw items.")
+    print("   Say 'stop', 'pause', or 'hey' to exit cook mode.")
+
+
+def cmd_cook_deactivate(args):
+    """Deactivate cook mode, print summary."""
+    state = _read_json(args.state_file)
+    if not state or not state.get("active"):
+        print("Cook mode is not active.")
+        sys.exit(1)
+
+    started = state.get("started_at", "unknown")
+    queued = state.get("messages_queued", 0)
+    task = state.get("task", "unknown")
+
+    cook_items = []
+    btw = _read_json(args.btw_file, {"items": [], "processed": []})
+    cook_items = [i for i in btw.get("items", [])
+                  if not i.get("processed") and i.get("cook_mode")]
+
+    state["active"] = False
+    state["ended_at"] = _now_local_iso()
+    _write_json(args.state_file, state)
+
+    print("\U0001f373 Cook mode deactivated!")
+    print(f"   Task: {task}")
+    print(f"   Session started: {started[:19]}")
+    print(f"   Messages queued: {queued}")
+
+    if cook_items:
+        print("\n   Queued messages:")
+        for i, item in enumerate(cook_items, 1):
+            ts = item.get("timestamp", "?")[:16]
+            print(f"   {i}. [{ts}] {item['text']}")
+        print(f"\n   Process these with: btw  (or btw_read)")
+    else:
+        print("   No messages were queued during this session.")
+
+
+def cmd_cook_queue(args):
+    """Append message to btw queue with cook-mode tag."""
+    btw_file = os.path.expanduser(args.btw_file)
+    state_file = os.path.expanduser(args.state_file)
+
+    if not os.path.exists(btw_file):
+        _write_json(btw_file, {"items": [], "processed": []})
+
+    btw = _read_json(btw_file, {"items": [], "processed": []})
+    btw.setdefault("items", []).append({
+        "text": args.message,
+        "timestamp": _now_local_iso(),
+        "processed": False,
+        "cook_mode": True,
+    })
+    _write_json(btw_file, btw)
+
+    state = _read_json(state_file)
+    if state:
+        state["messages_queued"] = state.get("messages_queued", 0) + 1
+        _write_json(state_file, state)
+
+    count = len([i for i in btw["items"] if not i.get("processed")])
+    print(f"\U0001f4dd Queued ({count} pending)")
+
+
+def cmd_cook_check_exit(args):
+    """Check if message matches exit keywords. exit 0=yes, 1=no (print exit/continue)."""
+    state = _read_json(args.state_file, {})
+    keywords = state.get("exit_keywords",
+                         ["stop", "pause", "hey", "hey claude", "hold on", "wait", "halt"])
+
+    msg = args.message.strip().lower()
+
+    for kw in keywords:
+        if msg == kw or msg.startswith(kw + " ") or msg.startswith(kw + ",") or msg.startswith(kw + "."):
+            print("exit")
+            sys.exit(0)
+
+    if msg.startswith("/uncook"):
+        print("exit")
+        sys.exit(0)
+
+    print("continue")
+
+
+# ── pin subcommands ─────────────────────────────────────────────────────
+
+def cmd_pin_add(args):
+    """Add a pin to the pinboard."""
+    board = _read_json(args.file, {"version": 1, "notes": [], "last_updated": None, "last_updated_by": None})
+
+    note = {
+        "id": str(uuid.uuid4())[:8],
+        "text": args.text,
+        "priority": args.priority,
+        "project": args.project,
+        "color": args.color,
+        "created_at": _now_local_iso(),
+        "created_by": args.agent,
+        "done": False,
+    }
+    board.setdefault("notes", []).append(note)
+    board["last_updated"] = _now_local_iso()
+    board["last_updated_by"] = args.agent
+    _write_json(args.file, board)
+    print(f"Pinned: [{note['id']}] {note['text']}")
+
+
+def cmd_pin_list(args):
+    """List all pins."""
+    board = _read_json(args.file, {"notes": []})
+    notes = board.get("notes", [])
+    if not notes:
+        print("  (pinboard empty)")
+    else:
+        for n in notes:
+            status = "x" if n.get("done") else " "
+            pri_map = {"high": "!", "medium": "-", "low": "."}
+            p = pri_map.get(n.get("priority", "medium"), "-")
+            proj = f' [{n["project"]}]' if n.get("project") else ""
+            print(f'  [{status}] {p} {n["id"]}: {n["text"]}{proj}')
+
+
+def cmd_pin_done(args):
+    """Mark a pin as done."""
+    board = _read_json(args.file, {"notes": []})
+    found = False
+    for n in board.get("notes", []):
+        if n["id"].startswith(args.id_prefix):
+            n["done"] = True
+            n["completed_at"] = _now_local_iso()
+            n["completed_by"] = args.agent
+            print(f"Done: {n['id']}: {n['text']}")
+            found = True
+            break
+    if not found:
+        print(f"Note not found: {args.id_prefix}")
+    else:
+        board["last_updated"] = _now_local_iso()
+        _write_json(args.file, board)
+
+
+def cmd_pin_remove(args):
+    """Remove a pin."""
+    board = _read_json(args.file, {"notes": []})
+    original_len = len(board.get("notes", []))
+    board["notes"] = [n for n in board.get("notes", []) if not n["id"].startswith(args.id_prefix)]
+    if len(board["notes"]) < original_len:
+        board["last_updated"] = _now_local_iso()
+        _write_json(args.file, board)
+        print(f"Removed note: {args.id_prefix}")
+    else:
+        print(f"Note not found: {args.id_prefix}")
+
+
+def cmd_pin_update(args):
+    """Update a pin with rich details."""
+    board = _read_json(args.file, {"notes": []})
+    found = False
+    for n in board.get("notes", []):
+        if n["id"].startswith(args.id_prefix):
+            if args.details:
+                n["details"] = args.details
+            if args.code:
+                n["code"] = args.code
+            if args.issue:
+                n["issue"] = args.issue
+            if args.verify:
+                n["verify"] = args.verify
+            if args.links_json:
+                new_links = json.loads(args.links_json)
+                existing = n.get("links", [])
+                existing.extend(new_links)
+                n["links"] = existing
+            n["updated_at"] = _now_local_iso()
+            n["updated_by"] = args.agent
+            print(f"Updated: {n['id']}: {n['text']}")
+            found = True
+            break
+    if not found:
+        print(f"Note not found: {args.id_prefix}")
+    else:
+        board["last_updated"] = _now_local_iso()
+        _write_json(args.file, board)
+
+
+def cmd_pin_last_id(args):
+    """Get the ID of the last pin."""
+    board = _read_json(args.file, {"notes": []})
+    notes = board.get("notes", [])
+    if notes:
+        print(notes[-1]["id"])
+    else:
+        print("")
+
+
+def cmd_pin_clear_done(args):
+    """Clear all done pins."""
+    board = _read_json(args.file, {"notes": []})
+    before = len(board.get("notes", []))
+    board["notes"] = [n for n in board.get("notes", []) if not n.get("done")]
+    after = len(board["notes"])
+    board["last_updated"] = _now_local_iso()
+    _write_json(args.file, board)
+    print(f"Cleared {before - after} done notes ({after} remaining)")
+
+
+def cmd_pin_read_context(args):
+    """Read pinboard and output formatted context for hook injection."""
+    board = _read_json(args.file, {"notes": []})
+    notes = [p for p in board.get("notes", []) if not p.get("done")]
+    if not notes:
+        print("No active pins.")
+        return
+
+    human_pins = [p for p in notes if p.get("needs_human")]
+    regular_pins = [p for p in notes if not p.get("needs_human")]
+    lines = []
+    if human_pins:
+        lines.append(f"ATTENTION: {len(human_pins)} pin(s) need human response:")
+        for p in human_pins:
+            tag = f' [{p["tag"]}]' if p.get("tag") else ""
+            proj = f' ({p["project"]})' if p.get("project") else ""
+            lines.append(f'  * {p["id"]}: {p["text"][:120]}{tag}{proj}')
+    if regular_pins:
+        lines.append(f"{len(regular_pins)} active pin(s):")
+        for p in regular_pins:
+            tag = f' [{p["tag"]}]' if p.get("tag") else ""
+            proj = f' ({p["project"]})' if p.get("project") else ""
+            lines.append(f'  * {p["text"][:120]}{tag}{proj}')
+    print("\n".join(lines))
+
+
+def cmd_pin_build_links(args):
+    """Build links JSON array from label|url pair, merging with existing."""
+    links = json.loads(args.existing) if args.existing else []
+    if "|" in args.link:
+        label, url = args.link.split("|", 1)
+    else:
+        label = args.link
+        url = args.link
+    links.append({"label": label, "url": url})
+    print(json.dumps(links))
+
+
+# ── dispatch subcommands ────────────────────────────────────────────────
+
+def cmd_dispatch_write_task(args):
+    """Write a dispatch task JSON file."""
+    task = {
+        "id": args.id,
+        "agent": args.agent,
+        "project_dir": args.project_dir,
+        "prompt": args.prompt,
+        "max_turns": args.max_turns,
+        "caller": args.caller,
+        "parent_task": args.parent_task,
+        "priority": args.priority,
+        "depth": args.depth,
+        "status": "queued",
+        "created_at": args.created_at or _now_iso(),
+        "issue_number": args.issue_number,
+        "use_tmux": args.use_tmux.lower() == "true",
+        "use_worktree": args.use_worktree.lower() == "true",
+    }
+    _write_json(args.file, task)
+
+
+def cmd_dispatch_parse_task(args):
+    """Parse task JSON and output shell-safe variable assignments."""
+    data = _read_json(args.file)
+    if not data:
+        print("ERROR=failed to parse task", file=sys.stderr)
+        sys.exit(1)
+
+    prompt_file = args.file.replace(".json", ".prompt")
+    with open(prompt_file, "w") as pf:
+        pf.write(data.get("prompt", ""))
+
+    print(f"agent={data.get('agent', '')}")
+    print(f"project_dir={data.get('project_dir', '')}")
+    print(f"max_turns={data.get('max_turns', 30)}")
+    print(f"depth={data.get('depth', 0)}")
+    print(f"caller={data.get('caller', 'unknown')}")
+    print(f"issue_number={data.get('issue_number', '')}")
+    print(f"use_tmux={str(data.get('use_tmux', False)).lower()}")
+    print(f"use_worktree={str(data.get('use_worktree', False)).lower()}")
+
+
+def cmd_dispatch_update_status(args):
+    """Update status field in a task file."""
+    data = _read_json(args.file)
+    if not data:
+        return
+    data["status"] = args.status
+    if args.started_at:
+        data["started_at"] = args.started_at
+    _write_json(args.file, data)
+
+
+def cmd_dispatch_mark_done(args):
+    """Mark a task as done, write to done dir."""
+    data = _read_json(args.active_file)
+    if not data:
+        return
+    data["status"] = "done"
+    data["exit_code"] = args.exit_code
+    data["completed_at"] = args.completed_at or _now_iso()
+    _write_json(args.done_file, data)
+
+
+def cmd_dispatch_get_priority(args):
+    """Get priority from a task file."""
+    data = _read_json(args.file)
+    print(data.get("priority", "normal"))
+
+
+def cmd_dispatch_print_task(args):
+    """Print task info in specified format."""
+    data = _read_json(args.file)
+    if not data:
+        return
+    if args.format == "active":
+        print(f"  ACTIVE  {data['id']}  agent={data['agent']}  ")
+        print(f"          {data.get('prompt', '')[:80]}...")
+    elif args.format == "queued":
+        print(f"  QUEUED  {data['id']}  agent={data['agent']}  pri={data.get('priority', 'normal')}")
+    else:
+        status = data.get("status", "?")
+        print(f"{status:>8}  {data['id']}  {data['agent']}  {data.get('prompt', '')[:60]}...")
+
+
+def cmd_dispatch_cancel(args):
+    """Cancel a queued task."""
+    data = _read_json(args.queue_file)
+    if not data:
+        sys.exit(1)
+    data["status"] = "cancelled"
+    _write_json(args.done_file, data)
+
+
+def cmd_dispatch_write_context(args):
+    """Write dispatch context JSON for pre-loading agent context."""
+    ctx = {
+        "agent_name": args.agent,
+        "repo": args.repo,
+        "issue_number": args.issue if args.issue else None,
+        "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "created_by": os.environ.get("CLAUDE_AGENT_NAME", "unknown"),
+        "consumed": False,
+    }
+
+    if args.briefing:
+        ctx["briefing_summary"] = args.briefing
+    if args.instructions:
+        ctx["custom_instructions"] = args.instructions
+
+    if args.issue and args.repo:
+        import urllib.request
+        api_url = args.gitea_api_url or os.environ.get("GITEA_API_URL", "https://git.wastelandwares.com/api/v1")
+        token = args.gitea_token or os.environ.get("GITEA_API_TOKEN", "")
+        try:
+            url = f"{api_url}/repos/{args.repo}/issues/{args.issue}?token={token}"
+            req = urllib.request.Request(url)
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                issue = json.loads(resp.read())
+            ctx["issue_bodies"] = [{
+                "number": issue["number"],
+                "title": issue["title"],
+                "body": issue.get("body", ""),
+                "labels": [l["name"] for l in issue.get("labels", [])],
+            }]
+        except Exception:
+            pass
+
+    project_name = args.repo.split("/")[-1] if args.repo else ""
+    if project_name:
+        project_dir = os.path.expanduser(f"~/projects/{project_name}")
+        if os.path.isdir(project_dir):
+            try:
+                result = subprocess.run(
+                    ["git", "log", "--oneline", "-15"],
+                    capture_output=True, text=True, timeout=5,
+                    cwd=project_dir
+                )
+                if result.returncode == 0:
+                    ctx["recent_commits"] = result.stdout.strip()
+            except Exception:
+                pass
+
+    _write_json(args.file, ctx)
+    print(f'Dispatch context written for {ctx["agent_name"]} ({ctx["repo"]})')
+
+
+def cmd_dispatch_consume_context(args):
+    """Mark dispatch context as consumed."""
+    data = _read_json(args.file)
+    if not data:
+        return
+    data["consumed"] = True
+    data["consumed_by"] = args.agent
+    _write_json(args.file, data)
+
+
+# ── btw subcommands ─────────────────────────────────────────────────────
+
+def cmd_btw_count(args):
+    """Count pending btw items."""
+    data = _read_json(args.file, {"items": []})
+    count = len([i for i in data.get("items", []) if not i.get("processed")])
+    print(count)
+
+
+def cmd_btw_read(args):
+    """Read pending btw items."""
+    data = _read_json(args.file, {"items": []})
+    pending = [i for i in data.get("items", []) if not i.get("processed")]
+    if not pending:
+        print("(no pending btw items)")
+    else:
+        for item in pending:
+            ts = item.get("timestamp", "?")[:16]
+            print(f"[{ts}] {item['text']}")
+
+
+def cmd_btw_process_all(args):
+    """Mark all pending btw items as processed."""
+    data = _read_json(args.file, {"items": [], "processed": []})
+    pending = [i for i in data.get("items", []) if not i.get("processed")]
+    for item in data.get("items", []):
+        if not item.get("processed"):
+            item["processed"] = True
+            item["processed_at"] = _now_local_iso()
+    _write_json(args.file, data)
+    for item in pending:
+        ts = item.get("timestamp", "?")[:16]
+        print(f"[{ts}] {item['text']}")
+
+
+# ── hook subcommands ────────────────────────────────────────────────────
+
+def cmd_hook_parse_input(args):
+    """Read JSON from stdin, output requested keys as key=value pairs."""
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        data = {}
+    for key in args.keys:
+        val = data.get(key, "")
+        print(f"{key}={val}")
+
+
+def cmd_hook_build_output(args):
+    """Build hook output JSON with additionalContext from stdin."""
+    context = sys.stdin.read() if not args.context else args.context
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": args.event_name,
+            "additionalContext": context,
+        }
+    }
+    print(json.dumps(output))
+
+
+def cmd_hook_read_dispatch_context(args):
+    """Read dispatch context and output formatted text for hook injection."""
+    data = _read_json(args.file)
+    if not data:
+        return
+
+    created = data.get("created_at", "")
+    if created:
+        try:
+            created_dt = datetime.datetime.fromisoformat(created.replace("Z", "+00:00"))
+            now = datetime.datetime.now(datetime.timezone.utc)
+            if (now - created_dt).total_seconds() > 300:
+                return
+        except Exception:
+            pass
+
+    lines = []
+    if data.get("briefing_summary"):
+        lines.append("## PM Briefing Summary")
+        lines.append(data["briefing_summary"])
+        lines.append("")
+    if data.get("issue_bodies"):
+        lines.append("## Issue Details")
+        for issue in data["issue_bodies"]:
+            lines.append(f'### #{issue.get("number", "?")} \u2014 {issue.get("title", "")}')
+            lines.append(issue.get("body", ""))
+            labels = issue.get("labels", [])
+            if labels:
+                lines.append(f'Labels: {", ".join(labels)}')
+            lines.append("")
+    if data.get("recent_commits"):
+        lines.append("## Recent Commits")
+        lines.append(data["recent_commits"])
+        lines.append("")
+    if data.get("cross_dependencies"):
+        lines.append("## Cross-Project Dependencies")
+        lines.append(data["cross_dependencies"])
+        lines.append("")
+    if data.get("phase_plan"):
+        lines.append("## Phase Plan")
+        lines.append(data["phase_plan"])
+        lines.append("")
+    if data.get("custom_instructions"):
+        lines.append("## Instructions from PM")
+        lines.append(data["custom_instructions"])
+        lines.append("")
+
+    print("\n".join(lines))
+
+
+# ── stream subcommands ──────────────────────────────────────────────────
+
+def cmd_stream_extract_result(args):
+    """Extract text result from stream-json output file."""
+    try:
+        with open(args.file) as f:
+            lines = f.readlines()
+    except Exception:
+        return
+
+    text_parts = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+            t = event.get("type", "")
+            if t == "result":
+                if "result" in event:
+                    text_parts.append(event["result"])
+            elif t == "assistant":
+                msg = event.get("message", {})
+                if isinstance(msg, dict):
+                    for block in msg.get("content", []):
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text_parts.append(block["text"])
+        except (json.JSONDecodeError, KeyError):
+            continue
+
+    if text_parts:
+        print("\n".join(text_parts))
+    else:
+        for line in lines[-20:]:
+            print(line.rstrip())
+
+
+def cmd_stream_pretty_print(args):
+    """Pretty-print stream-json events from stdin (for tail -f piping)."""
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            e = json.loads(line)
+            t = e.get("type", "")
+            if t == "assistant":
+                msg = e.get("message", {})
+                if isinstance(msg, dict):
+                    for b in msg.get("content", []):
+                        if isinstance(b, dict) and b.get("type") == "text":
+                            print(b["text"], end="", flush=True)
+                elif isinstance(msg, str):
+                    print(msg, end="", flush=True)
+            elif t == "tool_use":
+                name = e.get("tool", e.get("name", "?"))
+                print(f"\n--- [{name}] ---", flush=True)
+            elif t == "tool_result":
+                print("--- [result] ---\n", flush=True)
+            elif t == "result":
+                print("\n=== DONE ===", flush=True)
+        except Exception:
+            pass
+
+
+# ── refine subcommands ──────────────────────────────────────────────────
+
+def cmd_refine_ollama(args):
+    """Call Ollama API with prompt from file, print response text."""
+    with open(args.prompt_file) as f:
+        prompt_text = f.read()
+
+    payload = json.dumps({
+        "model": args.model,
+        "prompt": prompt_text,
+        "stream": False,
+        "options": {"num_predict": args.max_tokens, "temperature": 0.4},
+    })
+
+    try:
+        r = subprocess.run(
+            ["curl", "-sf", args.url, "-d", payload],
+            capture_output=True, text=True, timeout=120
+        )
+        if r.returncode == 0 and r.stdout:
+            resp = json.loads(r.stdout)
+            print(resp.get("response", ""))
+    except Exception:
+        pass
+
+
+def cmd_refine_project_context(args):
+    """Read project context from context graph JSON."""
+    graph_path = os.path.expanduser(args.graph_file)
+    try:
+        with open(graph_path) as f:
+            g = json.load(f)
+        p = g.get("projects", {}).get(args.project, {})
+        print(f"Project: {args.project}")
+        print(f"Description: {p.get('blurb', 'unknown')}")
+        print(f"Tech stack: {', '.join(p.get('tech_stack', []))}")
+        print(f"Current sprint: {p.get('current_sprint', 'none')}")
+        print(f"Open issues: {p.get('open_issues', '?')}")
+        related = p.get("related_projects", [])
+        if related:
+            print(f"Related projects: {', '.join(related)}")
+    except Exception:
+        print("Project context unavailable")
+
+
+# ── Main argument parser ────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="ww-json-tool",
+        description="WastelandWares JSON CLI \u2014 replaces inline Python in shell scripts",
+    )
+    sub = parser.add_subparsers(dest="group", help="Command group")
+
+    # ── json ──
+    json_p = sub.add_parser("json", help="Generic JSON operations")
+    json_sub = json_p.add_subparsers(dest="cmd")
+
+    p = json_sub.add_parser("safe-string", help="JSON-escape a string value")
+    p.add_argument("value")
+    p.set_defaults(func=cmd_json_safe_string)
+
+    p = json_sub.add_parser("get", help="Read a key from a JSON file")
+    p.add_argument("--file", required=True)
+    p.add_argument("--key", required=True)
+    p.add_argument("--default", default="")
+    p.set_defaults(func=cmd_json_get)
+
+    p = json_sub.add_parser("set", help="Set a key in a JSON file")
+    p.add_argument("--file", required=True)
+    p.add_argument("--key", required=True)
+    p.add_argument("--value", required=True)
+    p.set_defaults(func=cmd_json_set)
+
+    p = json_sub.add_parser("stdin-key", help="Read a key from JSON on stdin")
+    p.add_argument("--key", required=True)
+    p.add_argument("--default", default="")
+    p.set_defaults(func=cmd_json_stdin_key)
+
+    p = json_sub.add_parser("array-length", help="Read JSON array from stdin, print length")
+    p.add_argument("--default", default="?")
+    p.set_defaults(func=cmd_json_array_length)
+
+    p = json_sub.add_parser("build-object", help="Build JSON from key=value pairs")
+    p.add_argument("pairs", nargs="*")
+    p.add_argument("--file", default=None)
+    p.set_defaults(func=cmd_json_build_object)
+
+    # ── status ──
+    status_p = sub.add_parser("status", help="Agent status operations")
+    status_sub = status_p.add_subparsers(dest="cmd")
+
+    p = status_sub.add_parser("write", help="Write agent status file")
+    p.add_argument("--agent", required=True)
+    p.add_argument("--state", required=True)
+    p.add_argument("--task", required=True)
+    p.add_argument("--repo", default="")
+    p.add_argument("--issue", default="")
+    p.add_argument("--pid", type=int, required=True)
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_status_write)
+
+    p = status_sub.add_parser("heartbeat", help="Update heartbeat")
+    p.add_argument("--pid", type=int, required=True)
+    p.add_argument("--timestamp", default="")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_status_heartbeat)
+
+    p = status_sub.add_parser("set-avatar", help="Set avatar properties")
+    p.add_argument("--avatar-json", required=True)
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_status_set_avatar)
+
+    p = status_sub.add_parser("list", help="List all agent statuses (JSON)")
+    p.add_argument("--dir", required=True)
+    p.set_defaults(func=cmd_status_list)
+
+    p = status_sub.add_parser("list-human", help="List agent statuses (human-readable)")
+    p.add_argument("--dir", required=True)
+    p.set_defaults(func=cmd_status_list_human)
+
+    # ── tx ──
+    tx_p = sub.add_parser("tx", help="Transaction operations")
+    tx_sub = tx_p.add_subparsers(dest="cmd")
+
+    p = tx_sub.add_parser("begin", help="Begin a transaction")
+    p.add_argument("--id", required=True)
+    p.add_argument("--agent", required=True)
+    p.add_argument("--intent", required=True)
+    p.add_argument("--justification", required=True)
+    p.add_argument("--repo", default="")
+    p.add_argument("--issue", default="")
+    p.add_argument("--timestamp", default="")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_tx_begin)
+
+    p = tx_sub.add_parser("action", help="Log a transaction action")
+    p.add_argument("--what", required=True)
+    p.add_argument("--why", required=True)
+    p.add_argument("--timestamp", required=True)
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_tx_action)
+
+    p = tx_sub.add_parser("end", help="End a transaction")
+    p.add_argument("--outcome", required=True)
+    p.add_argument("--summary", default="")
+    p.add_argument("--timestamp", required=True)
+    p.add_argument("--file", required=True)
+    p.add_argument("--log-dir", required=True)
+    p.set_defaults(func=cmd_tx_end)
+
+    p = tx_sub.add_parser("recent", help="List recent transactions")
+    p.add_argument("--log-dir", required=True)
+    p.add_argument("--tx-dir", required=True)
+    p.add_argument("--count", type=int, default=10)
+    p.set_defaults(func=cmd_tx_recent)
+
+    # ── cook ──
+    cook_p = sub.add_parser("cook", help="Cook mode operations")
+    cook_sub = cook_p.add_subparsers(dest="cmd")
+
+    p = cook_sub.add_parser("read", help="Check if cook mode is active")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_cook_read)
+
+    p = cook_sub.add_parser("activate", help="Activate cook mode")
+    p.add_argument("--file", required=True)
+    p.add_argument("--task", default="Autonomous work session")
+    p.set_defaults(func=cmd_cook_activate)
+
+    p = cook_sub.add_parser("deactivate", help="Deactivate cook mode")
+    p.add_argument("--state-file", required=True)
+    p.add_argument("--btw-file", required=True)
+    p.set_defaults(func=cmd_cook_deactivate)
+
+    p = cook_sub.add_parser("queue", help="Queue a message in cook mode")
+    p.add_argument("--btw-file", required=True)
+    p.add_argument("--state-file", required=True)
+    p.add_argument("--message", required=True)
+    p.set_defaults(func=cmd_cook_queue)
+
+    p = cook_sub.add_parser("check-exit", help="Check for exit keywords")
+    p.add_argument("--state-file", required=True)
+    p.add_argument("--message", required=True)
+    p.set_defaults(func=cmd_cook_check_exit)
+
+    # ── pin ──
+    pin_p = sub.add_parser("pin", help="Pinboard operations")
+    pin_sub = pin_p.add_subparsers(dest="cmd")
+
+    p = pin_sub.add_parser("add", help="Add a pin")
+    p.add_argument("--file", required=True)
+    p.add_argument("--text", required=True)
+    p.add_argument("--priority", default="medium")
+    p.add_argument("--project", default="")
+    p.add_argument("--color", default="yellow")
+    p.add_argument("--agent", default="unknown")
+    p.set_defaults(func=cmd_pin_add)
+
+    p = pin_sub.add_parser("list", help="List pins")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_pin_list)
+
+    p = pin_sub.add_parser("done", help="Mark a pin done")
+    p.add_argument("--file", required=True)
+    p.add_argument("--id-prefix", required=True)
+    p.add_argument("--agent", default="unknown")
+    p.set_defaults(func=cmd_pin_done)
+
+    p = pin_sub.add_parser("remove", help="Remove a pin")
+    p.add_argument("--file", required=True)
+    p.add_argument("--id-prefix", required=True)
+    p.set_defaults(func=cmd_pin_remove)
+
+    p = pin_sub.add_parser("update", help="Update a pin with rich details")
+    p.add_argument("--file", required=True)
+    p.add_argument("--id-prefix", required=True)
+    p.add_argument("--details", default="")
+    p.add_argument("--code", default="")
+    p.add_argument("--issue", default="")
+    p.add_argument("--verify", default="")
+    p.add_argument("--links-json", default="")
+    p.add_argument("--agent", default="unknown")
+    p.set_defaults(func=cmd_pin_update)
+
+    p = pin_sub.add_parser("last-id", help="Get last pin ID")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_pin_last_id)
+
+    p = pin_sub.add_parser("clear-done", help="Clear all done pins")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_pin_clear_done)
+
+    p = pin_sub.add_parser("read-context", help="Read pinboard for hook injection")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_pin_read_context)
+
+    p = pin_sub.add_parser("build-links", help="Build links JSON from label|url")
+    p.add_argument("--link", required=True)
+    p.add_argument("--existing", default="[]")
+    p.set_defaults(func=cmd_pin_build_links)
+
+    # ── dispatch ──
+    disp_p = sub.add_parser("dispatch", help="Dispatch operations")
+    disp_sub = disp_p.add_subparsers(dest="cmd")
+
+    p = disp_sub.add_parser("write-task", help="Write a dispatch task")
+    p.add_argument("--file", required=True)
+    p.add_argument("--id", required=True)
+    p.add_argument("--agent", required=True)
+    p.add_argument("--project-dir", required=True)
+    p.add_argument("--prompt", required=True)
+    p.add_argument("--max-turns", type=int, default=30)
+    p.add_argument("--caller", default="unknown")
+    p.add_argument("--parent-task", default="")
+    p.add_argument("--priority", default="normal")
+    p.add_argument("--depth", type=int, default=0)
+    p.add_argument("--issue-number", default="")
+    p.add_argument("--use-tmux", default="false")
+    p.add_argument("--use-worktree", default="false")
+    p.add_argument("--created-at", default="")
+    p.set_defaults(func=cmd_dispatch_write_task)
+
+    p = disp_sub.add_parser("parse-task", help="Parse task to shell vars")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_dispatch_parse_task)
+
+    p = disp_sub.add_parser("update-status", help="Update task status")
+    p.add_argument("--file", required=True)
+    p.add_argument("--status", required=True)
+    p.add_argument("--started-at", default="")
+    p.set_defaults(func=cmd_dispatch_update_status)
+
+    p = disp_sub.add_parser("mark-done", help="Mark task as done")
+    p.add_argument("--active-file", required=True)
+    p.add_argument("--done-file", required=True)
+    p.add_argument("--exit-code", type=int, required=True)
+    p.add_argument("--completed-at", default="")
+    p.set_defaults(func=cmd_dispatch_mark_done)
+
+    p = disp_sub.add_parser("get-priority", help="Get task priority")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_dispatch_get_priority)
+
+    p = disp_sub.add_parser("print-task", help="Print task info")
+    p.add_argument("--file", required=True)
+    p.add_argument("--format", choices=["active", "queued", "list"], default="list")
+    p.set_defaults(func=cmd_dispatch_print_task)
+
+    p = disp_sub.add_parser("cancel", help="Cancel a queued task")
+    p.add_argument("--queue-file", required=True)
+    p.add_argument("--done-file", required=True)
+    p.set_defaults(func=cmd_dispatch_cancel)
+
+    p = disp_sub.add_parser("write-context", help="Write dispatch context")
+    p.add_argument("--file", required=True)
+    p.add_argument("--agent", required=True)
+    p.add_argument("--repo", required=True)
+    p.add_argument("--issue", default="")
+    p.add_argument("--briefing", default="")
+    p.add_argument("--instructions", default="")
+    p.add_argument("--gitea-api-url", default="")
+    p.add_argument("--gitea-token", default="")
+    p.set_defaults(func=cmd_dispatch_write_context)
+
+    p = disp_sub.add_parser("consume-context", help="Mark context consumed")
+    p.add_argument("--file", required=True)
+    p.add_argument("--agent", required=True)
+    p.set_defaults(func=cmd_dispatch_consume_context)
+
+    # ── btw ──
+    btw_p = sub.add_parser("btw", help="BTW queue operations")
+    btw_sub = btw_p.add_subparsers(dest="cmd")
+
+    p = btw_sub.add_parser("count", help="Count pending items")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_btw_count)
+
+    p = btw_sub.add_parser("read", help="Read pending items")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_btw_read)
+
+    p = btw_sub.add_parser("process-all", help="Mark all as processed")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_btw_process_all)
+
+    # ── hook ──
+    hook_p = sub.add_parser("hook", help="Hook helper operations")
+    hook_sub = hook_p.add_subparsers(dest="cmd")
+
+    p = hook_sub.add_parser("parse-input", help="Parse hook JSON from stdin")
+    p.add_argument("--keys", nargs="+", required=True)
+    p.set_defaults(func=cmd_hook_parse_input)
+
+    p = hook_sub.add_parser("build-output", help="Build hook output JSON")
+    p.add_argument("--event-name", required=True)
+    p.add_argument("--context", default="")
+    p.set_defaults(func=cmd_hook_build_output)
+
+    p = hook_sub.add_parser("read-dispatch-context", help="Read dispatch context for injection")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_hook_read_dispatch_context)
+
+    # ── stream ──
+    stream_p = sub.add_parser("stream", help="Stream JSON operations")
+    stream_sub = stream_p.add_subparsers(dest="cmd")
+
+    p = stream_sub.add_parser("extract-result", help="Extract text from stream-json")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_stream_extract_result)
+
+    p = stream_sub.add_parser("pretty-print", help="Pretty-print stream-json from stdin")
+    p.set_defaults(func=cmd_stream_pretty_print)
+
+    # ── refine ──
+    refine_p = sub.add_parser("refine", help="Refinement operations")
+    refine_sub = refine_p.add_subparsers(dest="cmd")
+
+    p = refine_sub.add_parser("ollama", help="Call Ollama with prompt file")
+    p.add_argument("--prompt-file", required=True)
+    p.add_argument("--model", default="phi4-mini")
+    p.add_argument("--url", default="http://localhost:11434/api/generate")
+    p.add_argument("--max-tokens", type=int, default=800)
+    p.set_defaults(func=cmd_refine_ollama)
+
+    p = refine_sub.add_parser("project-context", help="Read project context from graph")
+    p.add_argument("--project", required=True)
+    p.add_argument("--graph-file", default="~/.claude/context-graph/graph.json")
+    p.set_defaults(func=cmd_refine_project_context)
+
+    # ── Parse and execute ──
+    args = parser.parse_args()
+    if not hasattr(args, "func"):
+        parser.print_help()
+        sys.exit(1)
+
+    try:
+        args.func(args)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bin/ww-json-tool.py
+++ b/tools/bin/ww-json-tool.py
@@ -17,7 +17,6 @@ import json
 import os
 import subprocess
 import sys
-import uuid
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────
@@ -43,7 +42,6 @@ def _write_json(path, data):
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     with open(path, "w") as f:
         json.dump(data, f, indent=2)
-    f.close()
 
 
 # ── json subcommands ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds pre/post comment count check to verify Claude actually left a review
- Workflow now **fails** if no review comment was posted (previously succeeded silently)
- Improved review prompt to require explicit output
- Added `ready_for_review` and `reopened` triggers

## Problem
PRs were passing `claude-review` checks with 0 review comments. The action ran successfully but Claude sometimes didn't post anything, and silence was treated as approval.

## Test plan
- [ ] Open a PR — verify review comment is posted and check passes
- [ ] If Claude fails to comment — verify the workflow fails with clear error

Part of cross-repo standardization (all 7 repos getting this fix).